### PR TITLE
Add Pokemon Trading manifest to Flipper Catalog

### DIFF
--- a/applications/GPIO/pokemon/manifest.yml
+++ b/applications/GPIO/pokemon/manifest.yml
@@ -1,0 +1,22 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/EstebanFuentealba/Flipper-Zero-Game-Boy-Pokemon-Trading.git
+    commit_sha: 6744eb607e9101a67d781b1bdf6334b1acb16236
+category: "GPIO"
+short_description: |
+  Pokemon exchange from Flipper Zero to Game Boy for Generation I (Pokemon Red, Blue, Yellow)
+name: "Pokemon Trading"
+id: "pokemon"
+version: "1.2"
+description: "@README_catalog.md"
+changelog: "@changelog.md"
+author: "Esteban Fuentealba"
+icon: "pokemon_10px.png"
+screenshots:
+  - ".flipcorg/gallery/1.png"
+  - ".flipcorg/gallery/2.png"
+  - ".flipcorg/gallery/3.png"
+  - ".flipcorg/gallery/4.png"
+  - ".flipcorg/gallery/5.png"
+  - ".flipcorg/gallery/6.png"


### PR DESCRIPTION
Add Pokemon Trading manifest to Flipper Catalog

# Application Submission

Pokemon exchange from Flipper Zero to Game Boy for Generation I (Pokemon Red, Blue, Yellow) using GPIO

# Extra Requirements 

- No

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/dev/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it

# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality

<img width="692" alt="Screen Shot 2023-06-23 at 15 59 21" src="https://github.com/flipperdevices/flipper-application-catalog/assets/442927/0ccc8978-3c42-4ea7-b5de-fb079770d9e5">

