### PR TITLE
Seader manifest

### DIFF
--- a/applications/NFC/seader/manifest.yml
+++ b/applications/NFC/seader/manifest.yml
@@ -3,8 +3,11 @@ sourcecode:
   location:
     origin: https://github.com/bettse/seader.git
     commit_sha: 32a62619120e29134dad560346c55eb60c1ae32d
-short_description: Seader
-description: "Requires addon: UART to mini-SIM adapter and HID SAM. Allows for reading credential from HID iClass, iClass SE, Desfire EV1, and Seos. Credentials can be saved in Flipper picopass format or as agnostic format for later features"
+short_description: "Allows for reading credential from HID iClass, iClass SE, Desfire EV1, and Seos"
+description: |
+  Allows for reading credential from HID iClass, iClass SE, Desfire EV1, and Seos. Credentials can be saved in Flipper picopass format or as agnostic format for later features.
+  Requires addon: UART to mini-SIM adapter and HID SAM. 
+  See full readme for wiring and more information: https://github.com/bettse/seader/blob/main/readme.md
 changelog: "@changelog.md"
 screenshots:
   - .flipcorg/gallery/menu.png

--- a/applications/NFC/seader/manifest.yml
+++ b/applications/NFC/seader/manifest.yml
@@ -1,0 +1,12 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/bettse/seader.git
+    commit_sha: 32a62619120e29134dad560346c55eb60c1ae32d
+short_description: Seader
+description: "Interface with a SAM from the Flipper Zero over UART"
+changelog: "@changelog.md"
+screenshots:
+  - .flipcorg/gallery/menu.png
+  - .flipcorg/gallery/pacs.png
+  - .flipcorg/gallery/save_menu.png

--- a/applications/NFC/seader/manifest.yml
+++ b/applications/NFC/seader/manifest.yml
@@ -4,7 +4,7 @@ sourcecode:
     origin: https://github.com/bettse/seader.git
     commit_sha: 32a62619120e29134dad560346c55eb60c1ae32d
 short_description: Seader
-description: "Interface with a SAM from the Flipper Zero over UART"
+description: "Requires addon: UART to mini-SIM adapter and HID SAM. Allows for reading credential from HID iClass, iClass SE, Desfire EV1, and Seos. Credentials can be saved in Flipper picopass format or as agnostic format for later features"
 changelog: "@changelog.md"
 screenshots:
   - .flipcorg/gallery/menu.png


### PR DESCRIPTION
~~I know the app catalog hasn't been launched, I just wanted to try out the process.  No rush.~~ I see there are merged PRs already, I guess I'm not early.

I did notice the markdown support (https://github.com/bettse/flipper-application-catalog/blob/main/documentation/Manifest.md#markdown-support) didn't work with my readme since I'd craft it originally for GitLab/GitHub.  The manifest validation tool was really helpful.

# Application Submission

- Allows reading HID iClass SE and HID Seos cards when used with HID SAM.

# Extra Requirements 

- Requires hardware add on to interface with SAM over UART.  
- Can be https://github.com/killergeek/nard or https://www.mikroe.com/smart-card-2-click 
- plus the HID SAM

# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/dev/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it

# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
