### PR TITLE
Battery Checker

### DIFF
--- a/applications/GPIO/battery_checker/manifest.yml
+++ b/applications/GPIO/battery_checker/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Programistich/battery_checker.git
-    commit_sha: 4b23b94c26613bdf9ca42a9dd4433b54b6a8e140
+    commit_sha: 4e513d536350147024319fa1997164a66cb1f525
 short_description: External battery checker
 description: "@README.md"
 changelog: "@CHANGELOG.md"

--- a/applications/GPIO/battery_checker/manifest.yml
+++ b/applications/GPIO/battery_checker/manifest.yml
@@ -1,0 +1,11 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Programistich/battery_checker.git
+    commit_sha: 4b23b94c26613bdf9ca42a9dd4433b54b6a8e140
+short_description: External battery checker
+description: "@README.md"
+changelog: "@CHANGELOG.md"
+screenshots:
+- screenshots/first.png
+- screenshots/second.png


### PR DESCRIPTION
# Application Submission

ADC for Flipper with a reference voltage of 2.5V. Suitable for measuring battery voltage up to 2.5V. Using an external divider, it is possible to change the measuring range.

# Extra Requirements 

External divider for connect to battery and Flipper (GND, PC3 GPIO)

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/main/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it

# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality