### PR TITLE
Update ESP flasher (v1.1)

### DIFF
--- a/applications/GPIO/esp_flasher/manifest.yml
+++ b/applications/GPIO/esp_flasher/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/0xchocolate/flipperzero-esp-flasher.git
-    commit_sha: 7744b4ed60d47c881913d0ba0e0a4612d8e21c04
+    commit_sha: 70505e77448ce469a3f64c489725cb2255f63a06
 short_description: "Flipper Zero app to flash ESP chips from the device (no computer connection needed!)"
 description: "@./docs/README.md"
 changelog: "@./docs/changelog.md"


### PR DESCRIPTION
# Application Submission

- [ Describe your application here ]

ESP flasher now automatically enters the bootloader and resets supported boards (including flipper official wifi dev board) using RTS and DTR pins. Also added notifications (blue LED when flashing, vibrate when done).

# Extra Requirements 

- [ Describe if your application requires any extra hardware or software ]

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I validated my manifest [to be valid](../blob/HEAD/documentation/Contributing.md#validating-manifest)

# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
