### PR TITLE
Add "EM4100 key generator" app - now with the proper version

### DIFF
--- a/applications/RFID/key_generator/README.md
+++ b/applications/RFID/key_generator/README.md
@@ -1,3 +1,2 @@
-## Status
-
-[![key_generator](https://catalog.flipperzero.one/application/key_generator/widget)](https://catalog.flipperzero.one/application/key_generator/page)
+# fz-em4100-generator
+A program that generates universal keys from a EM4100 key

--- a/applications/RFID/key_generator/README.md
+++ b/applications/RFID/key_generator/README.md
@@ -1,2 +1,5 @@
-# fz-em4100-generator
 A program that generates universal keys from a EM4100 key
+
+## Status
+
+[![key_generator](https://catalog.flipperzero.one/application/key_generator/widget)](https://catalog.flipperzero.one/application/key_generator/page)

--- a/applications/RFID/key_generator/manifest.yml
+++ b/applications/RFID/key_generator/manifest.yml
@@ -1,11 +1,11 @@
 sourcecode:
   type: git
   location:
-    origin: https://github.com/xMasterX/all-the-plugins.git
-    commit_sha: 1606da9d9f0dbdc239387c9fb061bb25b4e94720
-    subdir: apps_source_code/fz-em4100-generator
-description: "Generates EM4100 key lists from selected rfid key file for RFID fuzzer app"
+    origin: https://github.com/Milk-Cool/fz-em4100-generator.git
+    commit_sha: d2901a9d74224432aaf3f68b6cdf884b200acd02
+short_description: "RFID potential universal keys generator"
+description: "@README.md"
 changelog: "v1.0 - Initial release"
-author: "@Milk-Cool"
+author: "milk_cool"
 screenshots:
-  - "./img/1.png"
+  - "./.flipcorg/gallery/Screenshot-20230223-203332.png"

--- a/applications/RFID/key_generator/manifest.yml
+++ b/applications/RFID/key_generator/manifest.yml
@@ -2,10 +2,10 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Milk-Cool/fz-em4100-generator.git
-    commit_sha: d2901a9d74224432aaf3f68b6cdf884b200acd02
+    commit_sha: d8b67d779fa834cc28ca2f0d0ca7607ff8a96f65
 short_description: "RFID potential universal keys generator"
 description: "@README.md"
-changelog: "v1.0 - Initial release"
+changelog: "v1.1 - Increased version so that it shows up in the catalog"
 author: "milk_cool"
 screenshots:
   - "./.flipcorg/gallery/Screenshot-20230223-203332.png"


### PR DESCRIPTION
# Application Submission

- This PR fixes the issue described in #80 - the app didn't have `fap_version` in its manifest, which led to it being replaced by an automatically geenerated version.

# Extra Requirements 

- none

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I validated my manifest [to be valid](../blob/HEAD/documentation/Contributing.md#validating-manifest)

# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
