### PR TITLE
TAS Playback (0.1)

### DIFF
--- a/applications/GPIO/tas_playback/manifest.yml
+++ b/applications/GPIO/tas_playback/manifest.yml
@@ -1,0 +1,11 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/rcombs/tas-playback.git
+    commit_sha: 7d0f3d817a267afabfff4cf61dfc7ae0d5cef60f
+    subdir: flipper
+description: "@README.md"
+changelog: "@changelog.md"
+screenshots:
+  - screenshots/file-select.png
+  - screenshots/running.png


### PR DESCRIPTION
# Application Submission

This app plays back tool-assisted speedrun files on video game consoles (currently only the Nintendo 64)

# Extra Requirements 

This reads files from the microSD card and sends output to a game console connected via the GPIO pins. This usually requires modifying a controller extension cable.

# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [ ] I validated my manifest [to be valid](../blob/HEAD/documentation/Contributing.md#validating-manifest)

# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
