### PR TITLE
Add MAX31855 Thermocouple Sensor App

### DIFF
--- a/applications/GPIO/max31855/manifest.yml
+++ b/applications/GPIO/max31855/manifest.yml
@@ -1,0 +1,13 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/skotopes/flipperzero_max31855.git
+    commit_sha: ff01fa5da25b06cb5394be710e3ffb0bad4c7ef7
+short_description: MAX31855 Thermocouple Sensor App
+description: "@ReadMe.md"
+changelog: "@ChangeLog.md"
+screenshots:
+  - screenshots/0.png
+  - screenshots/1.png
+  - screenshots/2.png
+  - screenshots/3.png


### PR DESCRIPTION
# Application Submission

- Add MAX31855 Thermocouple Sensor App


# Extra Requirements 

- Requires MAX31855 Sensor connected to GPIO


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s)


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
