### PR TITLE
Update wifi marauder app to v0.6.3

### DIFF
--- a/applications/GPIO/esp32_wifi_marauder/manifest.yml
+++ b/applications/GPIO/esp32_wifi_marauder/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/0xchocolate/flipperzero-wifi-marauder.git
-    commit_sha: 95f51c16ac2b9d0a708add8013240729d1c52cd0
+    commit_sha: 218f8c04dab6cbd501a98ec9a5e6d03f53b9fbf1
 id: "esp32_wifi_marauder"
 category: "GPIO"
 short_description: "Companion app for interfacing with ESP32 WiFi Marauder"


### PR DESCRIPTION
# Application Submission

- [ Describe your application here - its features or what has changed since the last version ]

Update wifi marauder app to v0.6.3 to support new bt wardrive and sourapple commands

# Extra Requirements 

- [ Describe if your application requires any extra hardware or software ]


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
