### PR TITLE
Add WCH SWIO Flasher v1.0

### DIFF
--- a/applications/Tools/wch_swio_flasher/README.md
+++ b/applications/Tools/wch_swio_flasher/README.md
@@ -1,0 +1,3 @@
+## Status
+
+[![wch_swio_flasher](https://catalog.flipperzero.one/application/wch_swio_flasher/widget)](https://catalog.flipperzero.one/application/wch_swio_flasher/page)

--- a/applications/Tools/wch_swio_flasher/manifest.yml
+++ b/applications/Tools/wch_swio_flasher/manifest.yml
@@ -1,0 +1,12 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/sukvojte/wch_swio_flasher.git
+    commit_sha: 6dd029338537f438b1f671f4775979f5058a0170
+description: "Flipper Zero WCH SWIO Flasher and debugger"
+changelog: "v1.0 - New Initial release"
+author: "Vojtech Suk"
+screenshots:
+  - "./screenshots/wchf_debug.png"
+  - "./screenshots/wchf_get_chip_info.png"
+  - "./screenshots/wchf_wiring.png"


### PR DESCRIPTION
# Application Submission

WCH SWIO debugger and flasher emulated on Flipper Zero tool - tool for flashing and debugging CH32V003 chip.

# Extra Requirements 

CH32V003 chip connected to Flipper Zero with external pull-up resistor required. Wiring described inside application itself.
You can found more info on project Readme.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
