### PR TITLE
Add malveke_gb_cartridge manifest

### DIFF
--- a/applications/GPIO/malveke_gb_cartridge/manifest.yml
+++ b/applications/GPIO/malveke_gb_cartridge/manifest.yml
@@ -1,0 +1,21 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/EstebanFuentealba/MALVEKE-Flipper-Zero.git
+    commit_sha: 5472f75b59d495cd5e9c877355a13a2837f561c5
+    subdir: flipper_companion_apps/applications/external/malveke_gb_cartridge
+category: "GPIO"
+short_description: |
+  MALVEKE app, its Interacts with GAME BOY and GAME BOY Color cartridges. You can Dump & Restore RAM and ROM.
+name: "[MALVEKE] GAME BOY Cartridge (GB/GBC)"
+id: "malveke_gb_cartridge"
+version: "1.0"
+description: "@README_catalog.md"
+changelog: "@docs/changelog.md"
+author: "Esteban Fuentealba"
+icon: "icons/icon.png"
+screenshots:
+  - ".flipcorg/gallery/1.png"
+  - ".flipcorg/gallery/2.png"
+  - ".flipcorg/gallery/3.png"
+  - ".flipcorg/gallery/4.png"


### PR DESCRIPTION
# Application Submission

- MALVEKE app, its Interacts with GAME BOY and GAME BOY Color cartridges. You can Dump & Restore RAM and ROM.


# Extra Requirements 

- [MALVEKE PCB](https://www.tindie.com/products/efuentealba/malveke-game-boy-tools-for-flipper-zero/)


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/GPIO/malveke_gb_cartridge/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
