### PR TITLE
Add malveke_gb_link_camera manifest

### DIFF
--- a/applications/GPIO/malveke_gb_link_camera/manifest.yml
+++ b/applications/GPIO/malveke_gb_link_camera/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/EstebanFuentealba/MALVEKE-Flipper-Zero.git
-    commit_sha: cbbb48b5bae0eb9fd6c81d1bb400d8381cfb0ae1
+    commit_sha: 762ed2ccb15d70f7b0741c7e2cb3e5ddf818c44f
     subdir: flipper_companion_apps/applications/external/malveke_gb_link_camera
 category: "GPIO"
 short_description: |


### PR DESCRIPTION
# Application Submission

- MALVEKE app, this application allows you to extract your GAME BOY Camera pictures via WIFI for easy sharing with your phone, tablet, or PC. It's user-friendly; simply connect it to your GAME BOY and print as usual. The device will store the images and share them on a web server via WIFI. You will need a printer cable or GAME BOY Color link cable for this.

# Extra Requirements 

- [MALVEKE PCB](https://www.tindie.com/products/efuentealba/malveke-game-boy-tools-for-flipper-zero/)
- GAME BOY Color 
- Cable Link

# Author Checklist (Fill this out)
- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/GPIO/malveke_gb_link_camera/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
