### PR TITLE
Add knitting row counter app

### DIFF
--- a/applications/Tools/knit_counter/manifest.yml
+++ b/applications/Tools/knit_counter/manifest.yml
@@ -1,0 +1,11 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/fridgepoet/knit-counter.git
+    commit_sha: ad5fd1cff277ef7b24a7ec7868628f10434789d1
+description: |
+  Counter that saves the count after exiting.
+  Useful for knitting.
+changelog: "@CHANGELOG.md"
+screenshots:
+  - ./screenshots/1.png


### PR DESCRIPTION
# Application Submission

- This is a counter which saves the count after exiting. 
- This can be used as a knitting row counter.


# Extra Requirements 

- None


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
