### PR TITLE
Add ufbt SDK Installation Instruction for Contibuting Guide

### DIFF
--- a/documentation/Contributing.md
+++ b/documentation/Contributing.md
@@ -41,6 +41,13 @@ source venv/bin/activate
 pip install -r tools/requirements.txt
 ```
 
+If you haven't yet installed the SDK for `ufbt`, you can install one within the virtual environment.
+
+```bash
+export UFBT_HOME=venv/ufbt
+ufbt update
+```
+
 Then run the validation script, passing it the path to your manifest file:
 
 ```bash

--- a/documentation/Contributing.md
+++ b/documentation/Contributing.md
@@ -41,10 +41,10 @@ source venv/bin/activate
 pip install -r tools/requirements.txt
 ```
 
-If you haven't yet installed the SDK for `ufbt`, you can install one within the virtual environment.
+If you haven't yet installed the SDK for `ufbt` for your current user, you can install one within the virtual environment.
 
 ```bash
-export UFBT_HOME=venv/ufbt
+export UFBT_HOME=`realpath venv/ufbt`
 ufbt update
 ```
 

--- a/tools/bundle.py
+++ b/tools/bundle.py
@@ -661,6 +661,13 @@ class Main:
 
     def _setup_imports(self):
         try:
+            subprocess.check_output(
+                [AppBundler.UFBT_COMMAND, "update"], encoding="utf-8"
+            )
+        except subprocess.CalledProcessError as e:
+            raise BundlerException(f"Could not update ufbt: {e}")
+        
+        try:
             ufbt_state_dir = subprocess.check_output(
                 [AppBundler.UFBT_COMMAND, "status", "sdk_dir"], encoding="utf-8"
             ).strip()


### PR DESCRIPTION
# Application Submission

Not an application submission.


# Extra Requirements 

Proposing adding some instructions to install the latest stable SDK as part of the contribution guide. 

Without running `ufbt update` or otherwise populating the ufbt's SDK dir, these instructions lead to a somewhat opaque error when running `tools/bundle.py`:
```
$> python3 tools/bundle.py --nolint applications/Infrared/ir_intervalometer/manifest.yml bundle.zip
10:24:51.235 [E] Could not find ufbt state dir: Command '['ufbt', 'status', 'sdk_dir']' returned non-zero exit status 1.
```

Running `ufbt status sdk_dir` will return the SDK path without obvious error, but exit with a non-zero code. 
```
$> ufbt status sdk_dir
/home/luna/.ufbt/current
$> echo $?
1
```

This PR add instructions to install the latest stable sdk via `ufbt` into the virtual environment for sanitary reasons.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
