### PR TITLE
Seader: Bump to v2.2

### DIFF
--- a/applications/NFC/seader/manifest.yml
+++ b/applications/NFC/seader/manifest.yml
@@ -2,10 +2,10 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/bettse/seader.git
-    commit_sha: cca8f894d42ee1f399477a06a472e78629e392a9
-short_description: "Allows for reading credential from HID iClass, iClass SE, Desfire EV1, and Seos"
+    commit_sha: 6004b3a03b2972a3445737195020db2e73337630
+short_description: "Allows for reading credential from HID iClass, iClass SE, Desfire EV1/EV2, and Seos"
 description: |
-  Allows for reading credential from HID iClass, iClass SE, Desfire EV1, and Seos. Credentials can be saved in an agnostic format, or as various Flipper formats (Prox, MFC, iClass, iClass SR), depending on the original type.
+  Allows for reading credential from HID iClass, iClass SE, Desfire EV1/EV2, and Seos. Credentials can be saved in an agnostic format, or as various Flipper formats (Prox, MFC, iClass, iClass SR), depending on the original type.
   Requires addon: UART to mini-SIM adapter and HID SAM. 
   See full readme for wiring and more information: https://github.com/bettse/seader/blob/main/readme.md
 changelog: "@changelog.md"


### PR DESCRIPTION
# Application Submission

- Fix saving diversifier for iClass SE (broke during NFC refactor)
- Add support for Desfire EV2
- Add capturing SIO for Desfire EV1/EV2
- Rename "Load" menu to "Saved" to align with NFC and RFID apps
- UI flow improvements

# Extra Requirements 

- Requires uart to sam interface ("nard")


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
