### PR TITLE
Update "Camera Suite" application to v1.5

### DIFF
--- a/applications/GPIO/camera_suite/manifest.yml
+++ b/applications/GPIO/camera_suite/manifest.yml
@@ -14,7 +14,7 @@ screenshots:
 short_description: "A camera suite application for the Flipper Zero ESP32-CAM module."
 sourcecode:
   location:
-    commit_sha: 850c70a7512cf3b279451876117f26654e85b82c
+    commit_sha: ef6a25ba46ceea3b13ae68c83da0aba76ae8ad6e
     origin: https://github.com/CodyTolene/Flipper-Zero-Camera-Suite.git
     subdir: fap
   type: git


### PR DESCRIPTION
# Application Submission

- Update "[ESP32] Camera Suite" application fap from v1.4 to v1.5.
- Removes use of an image that no longer exists in the new firmware.

# Extra Requirements 

- Firmware is required for the ESP32-CAM module, see readme [here](https://github.com/CodyTolene/Flipper-Zero-Camera-Suite).

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
