### PR TITLE
Update ublox commit to v0.4.

### DIFF
--- a/applications/GPIO/ublox/manifest.yml
+++ b/applications/GPIO/ublox/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/liamhays/ublox.git
-    commit_sha: 950f9991c69f3e20bcd577dee83094149f2568fc
+    commit_sha: 7d65c461e90e9ff88ad034f69ddcedf456ffd837
 description: "@apphub_readme.md"
 changelog: "@changelog.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

- Update ublox to compile under firmware 0.99-rc (fixes https://github.com/liamhays/ublox/issues/1) by changing FuriHalRtcDateTime to DateTime.

# Extra Requirements 

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

Generating the bundle gave errors about `SCons.Node` not having an attribute `FS`, but I think that happened last time I updated this app.

# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
