### PR TITLE
Updated noptel_lrf_sampler to 1.1

### DIFF
--- a/applications/GPIO/noptel_lrf_sampler/manifest.yml
+++ b/applications/GPIO/noptel_lrf_sampler/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Giraut/flipper_zero_noptel_lrf_sampler
-    commit_sha: bb002a65f8e68b9d6495e389093e00836d7a7adb
+    commit_sha: abc8a7bded96a949977985c1c5ab3b45a016e4ae
 short_description: Noptel LRF rangefinder sampler
 description: "Noptel LRF rangefinder sampler app for the Flipper Zero"
 changelog: "@Changelog.md"

--- a/applications/GPIO/noptel_lrf_sampler/manifest.yml
+++ b/applications/GPIO/noptel_lrf_sampler/manifest.yml
@@ -2,16 +2,18 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Giraut/flipper_zero_noptel_lrf_sampler
-    commit_sha: 66963894191869819052808988510063c5de53c3
+    commit_sha: 86b8f1f098795e4136eef3f3273bebf87b3fb2f5
 short_description: Noptel LRF rangefinder sampler
 description: "Noptel LRF rangefinder sampler app for the Flipper Zero"
 changelog: "@Changelog.md"
 screenshots:
-  - screenshots/gpio_menu.png
-  - screenshots/main_menu.png
-  - screenshots/configuration_menu.png
-  - screenshots/sample_smm.png
-  - screenshots/sample_cmm.png
-  - screenshots/sample_averaging.png
-  - screenshots/about.png
-  - screenshots/gpio_pin_connections.png
+  - screenshots/0-sample_averaging.png
+  - screenshots/1-sample_cmm.png
+  - screenshots/2-sample_smm.png
+  - screenshots/3-lrf_information.png
+  - screenshots/4-splash_version.png
+  - screenshots/5-app_description.png
+  - screenshots/6-gpio_pin_connections.png
+  - screenshots/7-configuration_menu.png
+  - screenshots/8-main_menu.png
+  - screenshots/9-gpio_menu.png

--- a/applications/GPIO/noptel_lrf_sampler/manifest.yml
+++ b/applications/GPIO/noptel_lrf_sampler/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Giraut/flipper_zero_noptel_lrf_sampler
-    commit_sha: 86b8f1f098795e4136eef3f3273bebf87b3fb2f5
+    commit_sha: a6068c1df3a97c8a02606a43506d4fdfa77693ff
 short_description: Noptel LRF rangefinder sampler
 description: "Noptel LRF rangefinder sampler app for the Flipper Zero"
 changelog: "@Changelog.md"

--- a/applications/GPIO/noptel_lrf_sampler/manifest.yml
+++ b/applications/GPIO/noptel_lrf_sampler/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Giraut/flipper_zero_noptel_lrf_sampler
-    commit_sha: a6068c1df3a97c8a02606a43506d4fdfa77693ff
+    commit_sha: bb002a65f8e68b9d6495e389093e00836d7a7adb
 short_description: Noptel LRF rangefinder sampler
 description: "Noptel LRF rangefinder sampler app for the Flipper Zero"
 changelog: "@Changelog.md"


### PR DESCRIPTION
# Application Submission

- Noptel LRF rangefinder sampler app

    New in version 1.1:
    - Added LRF information display
    - Save and restore the configuration
    - Nicer about screens

# Extra Requirements 

- Requires a [rangefinder module](https://noptel.fi/rangefinderhome) from [Noptel Oy](https://noptel.fi/)

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
