### PR TITLE
Updated noptel_lrf_sampler to 1.1

### DIFF
--- a/applications/GPIO/noptel_lrf_sampler/manifest.yml
+++ b/applications/GPIO/noptel_lrf_sampler/manifest.yml
@@ -2,16 +2,18 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Giraut/flipper_zero_noptel_lrf_sampler
-    commit_sha: 66963894191869819052808988510063c5de53c3
+    commit_sha: f154bd58b61bc3fd3a3318332131a0140b48e84c
 short_description: Noptel LRF rangefinder sampler
 description: "Noptel LRF rangefinder sampler app for the Flipper Zero"
 changelog: "@Changelog.md"
 screenshots:
-  - screenshots/gpio_menu.png
-  - screenshots/main_menu.png
-  - screenshots/configuration_menu.png
-  - screenshots/sample_smm.png
-  - screenshots/sample_cmm.png
-  - screenshots/sample_averaging.png
-  - screenshots/about.png
-  - screenshots/gpio_pin_connections.png
+  - screenshots/0-sample_averaging.png
+  - screenshots/1-sample_cmm.png
+  - screenshots/2-sample_smm.png
+  - screenshots/3-lrf_information.png
+  - screenshots/4-splash_version.png
+  - screenshots/5-app_description.png
+  - screenshots/6-gpio_pin_connections.png
+  - screenshots/7-configuration_menu.png
+  - screenshots/8-main_menu.png
+  - screenshots/9-gpio_menu.png


### PR DESCRIPTION
# Application Submission

- Noptel LRF rangefinder sampler app

    New in version 1.1:
     - Added LRF information display
     - Save and restore the configuration
     -  Nicer about screens


# Extra Requirements 

- Requires a [rangefinder module](https://noptel.fi/rangefinderhome) from [Noptel Oy](https://noptel.fi/)


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
