### PR TITLE
Updated noptel_lrf_sampler to 1.2

### DIFF
--- a/applications/GPIO/noptel_lrf_sampler/manifest.yml
+++ b/applications/GPIO/noptel_lrf_sampler/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Giraut/flipper_zero_noptel_lrf_sampler
-    commit_sha: f154bd58b61bc3fd3a3318332131a0140b48e84c
+    commit_sha: 90b20a29da4ffd327b9ef7ce5b69f7aa97198958
 short_description: Noptel LRF rangefinder sampler
 description: "Noptel LRF rangefinder sampler app for the Flipper Zero"
 changelog: "@Changelog.md"
@@ -14,6 +14,6 @@ screenshots:
   - screenshots/4-splash_version.png
   - screenshots/5-app_description.png
   - screenshots/6-gpio_pin_connections.png
-  - screenshots/7-configuration_menu.png
-  - screenshots/8-main_menu.png
-  - screenshots/9-gpio_menu.png
+  - screenshots/7-pointer_on_off_toggle.png
+  - screenshots/8-configuration_menu.png
+  - screenshots/9-main_menu.png


### PR DESCRIPTION
# Application Submission

- Noptel LRF rangefinder sampler app

  New in version 1.2:
  - Changed the power control pin from pin #&#x2060;⁠1 (+5V) to #&#x2060;⁠15 (C1)
  - Added Pointer ON/OFF toggle
  - Automatically start sampling when entering Sample
  - Automatically read the LRF's identification when entering LRF information
  - Save and restore the last selected submenu option


# Extra Requirements 

- Requires a [rangefinder module](https://noptel.fi/rangefinderhome) from [Noptel Oy](https://noptel.fi/)


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
