### PR TITLE
Seader: v2.7

### DIFF
--- a/applications/NFC/seader/manifest.yml
+++ b/applications/NFC/seader/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/bettse/seader.git
-    commit_sha: 9c86b7fbce013a327f0e52b1e4555833ccf752c3
+    commit_sha: f4821fd7a6c3ee06544317967aacbd5371d2b200
 short_description: "Allows for reading credential from HID iClass, iClass SE, Desfire EV1/EV2, and Seos"
 description: |
   Allows for reading credential from HID iClass, iClass SE, Desfire EV1/EV2, and Seos. Credentials can be saved in an agnostic format, or as various Flipper formats (Prox, MFC, iClass, iClass SR), depending on the original type.


### PR DESCRIPTION
# Application Submission

- Adds format parsing for H10301 and C1k35s
- After reading card, if it is H10301 or C1k35s then a "parse" menu will show above "save"

# Extra Requirements 

- Requires uart to sam interface ("nard")


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
