### PR TITLE
Updated noptel_lrf_sampler to 1.5

### DIFF
--- a/applications/GPIO/noptel_lrf_sampler/manifest.yml
+++ b/applications/GPIO/noptel_lrf_sampler/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Giraut/flipper_zero_noptel_lrf_sampler
-    commit_sha: 23b88fac49651a84cfc53b678a0ae64355943f14
+    commit_sha: 950961d61b7c2f75cd01c70c398ab929126bf9a0
 short_description: Noptel LRF rangefinder sampler
 description: "Noptel LRF rangefinder sampler app for the Flipper Zero"
 changelog: "@Changelog.md"
@@ -11,9 +11,9 @@ screenshots:
   - screenshots/1-sample_cmm.png
   - screenshots/2-sample_smm.png
   - screenshots/3-lrf_information.png
-  - screenshots/4-splash_version.png
-  - screenshots/5-app_description.png
-  - screenshots/6-gpio_pin_connections.png
-  - screenshots/7-pointer_on_off_toggle.png
-  - screenshots/8-configuration_menu.png
-  - screenshots/9-main_menu.png
+  - screenshots/4-laser_testing.png
+  - screenshots/5-splash_version.png
+  - screenshots/6-app_description.png
+  - screenshots/7-gpio_pin_connections.png
+  - screenshots/8-save_lrf_diagnostic.png
+  - screenshots/9-configuration_menu.png


### PR DESCRIPTION
# Application Submission

- Noptel LRF rangefinder sampler app

    New in version 1.5:
    - Added LRX laser tester
    - Added IR pointer tester

  *[Note: unlike the rest of this app which requires a Noptel rangefinder, you actually can test if those two new functions work properly with a TV remote if you want: they're just simple IR detectors, just driving the rangefinder to generate a signal the Flipper can detect at the same time, but they don't strictly need the rangefinder to be present]*


# Extra Requirements 

- Requires a [rangefinder module](https://noptel.fi/rangefinderhome) from [Noptel Oy](https://noptel.fi/)


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
