### PR TITLE
Updated noptel_lrf_sampler to 1.6

### DIFF
--- a/applications/GPIO/noptel_lrf_sampler/manifest.yml
+++ b/applications/GPIO/noptel_lrf_sampler/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Giraut/flipper_zero_noptel_lrf_sampler
-    commit_sha: 950961d61b7c2f75cd01c70c398ab929126bf9a0
+    commit_sha: 877593adcba5a7cf44fb448d13fdbe11e768da7f
 short_description: Noptel LRF rangefinder sampler
 description: "Noptel LRF rangefinder sampler app for the Flipper Zero"
 changelog: "@Changelog.md"


### PR DESCRIPTION
# Application Submission

- Noptel LRF rangefinder sampler app

  New in version 1.6:

  - Added baudrate setting
  - Faster automatic SMM sampling rate
  - Keep the backlight on when testing the LRX laser or the IR pointer
  - Undocumented feature can be enabled with a special configuration file (manufacturer only)


# Extra Requirements 

- Requires a [rangefinder module](https://noptel.fi/rangefinderhome) from [Noptel Oy](https://noptel.fi/)


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
