### PR TITLE
Add MagSpoof v0.7

### DIFF
--- a/applications/GPIO/magspoof/manifest.yml
+++ b/applications/GPIO/magspoof/manifest.yml
@@ -1,0 +1,15 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/zacharyweiss/magspoof_flipper.git
+    commit_sha: a8359cd4dc53561430152f2a16865aad8e2eece1
+description: |
+  Port of Samy Kamkar's MagSpoof project to the Flipper Zero. Emulates magstripe data wirelessly using an external electromagnet.
+
+  Reading & internal TX are works-in-progress; for more information, confer GitHub.
+changelog: "All version control & changes annotated on GitHub"
+screenshots:
+  - assets/start.png
+  - assets/emulate.png
+  - assets/settings.png
+  - assets/emulate_config.png


### PR DESCRIPTION
# Application Submission

- My MagSpoof app is a port of Samy Kamkar's original MagSpoof project, enabling wireless transmission of magstripe data.
- At present, emulation is supported with the assistance of a GPIO module consisting of an H-bridge, a coil, and a capacitor.
- The most recent revisions include the ability to set/save the pins used.
- Additional code is present that tests internal TX, and external (UART) RX; as these features are WIP and/or skunkworks, they currently are only accessible when the debug flag is set.
- There is code in my application that is FW-specific making use of additional GUI elements only available in CFWs; despite this, the code compiles (and works) happily across all current FWs, with `#ifdef FIRMWARE_ORIGIN_Official` used to conditionally replace / remove elements that differ by FW.

# Extra Requirements 

- External hardware is required as outlined above (hence selecting the `GPIO` category)
- Multiple boards have been produced to be compatible with my code; to mention a few:
  - [astro's flipspoof](https://www.tindie.com/products/astrowave/flipper-zero-magspoof-module/)
  - [Rabbit-Labs' Multi Pass MagSpoof Flipper Board](https://www.tindie.com/products/tehrabbitt/rabbit-labstm-multi-pass-magspoof-flipper-board/)
  - [ElectronicCats' Flipper Add-On Magspoof](https://electroniccats.com/store/flipper-add-on-magspoof/)


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/GPIO/magspoof/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
