### PR TITLE
Updated noptel_lrf_sampler to 1.7

### DIFF
--- a/applications/GPIO/noptel_lrf_sampler/manifest.yml
+++ b/applications/GPIO/noptel_lrf_sampler/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Giraut/flipper_zero_noptel_lrf_sampler
-    commit_sha: 54ca345b6198bc87b89687b00e237be7c4ca6e79
+    commit_sha: 7433d0a71bc0a6aa267d7f8167905e510a60c1dd
 short_description: Noptel LRF rangefinder sampler
 description: "Noptel LRF rangefinder sampler app for the Flipper Zero"
 changelog: "@Changelog.md"
@@ -12,8 +12,8 @@ screenshots:
   - screenshots/2-sample_smm.png
   - screenshots/3-lrf_information.png
   - screenshots/4-laser_testing.png
-  - screenshots/5-splash_version.png
-  - screenshots/6-app_description.png
+  - screenshots/5-usb_serial_passthrough.png
+  - screenshots/6-splash_version.png
   - screenshots/7-gpio_pin_connections.png
   - screenshots/8-save_lrf_diagnostic.png
   - screenshots/9-configuration_menu.png


### PR DESCRIPTION
# Application Submission

- Noptel LRF rangefinder sampler app

  New in version 1.7:

  - Added USB serial passthrough function

  *[Note: this USB serial passthrough function is generic. You can test it with any UART device if you want to ensure that it works. It doesn't have to talk to a Noptel rangefinder. The functionality is exactly the same as the USB-UART bridge in the GPIO app, but this re-implementation handles high-speed serial traffic properly, and it's part of this app because the PC1 pin needs to be high to control the rangefinder's power supply.]*


# Extra Requirements 

- Requires a [rangefinder module](https://noptel.fi/rangefinderhome) from [Noptel Oy](https://noptel.fi/)

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
