### PR TITLE
Updated noptel_lrf_sampler to 1.8

### DIFF
--- a/applications/GPIO/noptel_lrf_sampler/manifest.yml
+++ b/applications/GPIO/noptel_lrf_sampler/manifest.yml
@@ -2,17 +2,17 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Giraut/flipper_zero_noptel_lrf_sampler
-    commit_sha: 7433d0a71bc0a6aa267d7f8167905e510a60c1dd
+    commit_sha: 481e70fd9d31f0081fa69bc7399ca9d477f2d204
 short_description: Noptel LRF rangefinder sampler
 description: "Noptel LRF rangefinder sampler app for the Flipper Zero"
 changelog: "@Changelog.md"
 screenshots:
   - screenshots/0-sample_buffering.png
   - screenshots/1-sample_cmm.png
-  - screenshots/2-sample_smm.png
-  - screenshots/3-lrf_information.png
-  - screenshots/4-laser_testing.png
-  - screenshots/5-usb_serial_passthrough.png
+  - screenshots/2-lrf_information.png
+  - screenshots/3-laser_testing.png
+  - screenshots/4-usb_serial_passthrough1.png
+  - screenshots/5-usb_serial_passthrough2.png
   - screenshots/6-splash_version.png
   - screenshots/7-gpio_pin_connections.png
   - screenshots/8-save_lrf_diagnostic.png


### PR DESCRIPTION
# Application Submission

- Noptel LRF rangefinder sampler app

  New in version 1.8:

  - Added serial traffic monitor in the USB serial passthrough view
  - Added USB serial passthrough channel setting
  - Added utility to decode LRF serial traffic logged in the Flipper Zero CLI in real time


# Extra Requirements 

- Requires a [rangefinder module](https://noptel.fi/rangefinderhome) from [Noptel Oy](https://noptel.fi/)


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
