### PR TITLE
Add Flipagotchi v2.0.0

### DIFF
--- a/applications/GPIO/flipagotchi/manifest.yml
+++ b/applications/GPIO/flipagotchi/manifest.yml
@@ -1,0 +1,12 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Matt-London/pwnagotchi-flipper.git
+    commit_sha: 7734a26115efffb259117700da6389822b6c65c7
+    subdir: flipagotchi
+short_description: Flipagotchi
+author: "Matt-London"
+description: "./README.md"
+changelog: "All changes tracked on GitHub repository"
+screenshots:
+  - "screenshots/PwnZeroBaseWFace.png"


### PR DESCRIPTION
# Application Submission

- The flipagotchi application allows a pwnagotchi device (with the PwnZero plugin installed) to communicate with the Flipper Zero over serial
- It displays the screen of the pwnagotchi on the Flipper 


# Extra Requirements 

- Requires a connection to a pwnagotchi over UART and for that pwnagotchi to have the PwnZero plugin installed
- All steps specified in detail in the repository (https://github.com/Matt-London/pwnagotchi-flipper.git)


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
