### PR TITLE
Updated noptel_lrf_sampler to 1.9

### DIFF
--- a/applications/GPIO/noptel_lrf_sampler/manifest.yml
+++ b/applications/GPIO/noptel_lrf_sampler/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Giraut/flipper_zero_noptel_lrf_sampler
-    commit_sha: 481e70fd9d31f0081fa69bc7399ca9d477f2d204
+    commit_sha: 4eb3a48146e9da3c94c3f5f78d7b9c6894b8cd45
 short_description: Noptel LRF rangefinder sampler
 description: "Noptel LRF rangefinder sampler app for the Flipper Zero"
 changelog: "@Changelog.md"


### PR DESCRIPTION
# Application Submission

- Noptel LRF rangefinder sampler app

  New in version 1.9:

  - Correctly display the bytes at the left-hand side of the serial traffic screen in the passthrough view
  - Free the UART receive stream buffer in the main thread rather than in the receive thread
  - Added code to turn on the +5V pin as well as the PC1 pin when the app is running - currently compiled out
  - Minor corrections


# Extra Requirements 

- Requires a [rangefinder module](https://noptel.fi/rangefinderhome) from [Noptel Oy](https://noptel.fi/)


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
