### PR TITLE
flipboard_blinky v3.5

### DIFF
--- a/applications/GPIO/flipboard_blinky/manifest.yml
+++ b/applications/GPIO/flipboard_blinky/manifest.yml
@@ -1,0 +1,17 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/jamisonderek/flipboard.git
+    commit_sha: 24ee24014512bfc2ec6c6482fefdcf41561e2eed
+    subdir: flipblinky
+description: "@./gallery/README.md"
+changelog: "@./gallery/CHANGELOG.md"
+author: "CodeAllNight (MrDerekJamison)"
+screenshots:
+  - "gallery/00-blinky-splash.png"
+  - "gallery/02-blinky-config-text.png"
+  - "gallery/07-blinky-nametag.png"
+  - "gallery/06-blinky-qrcode.png"
+  - "gallery/01-blinky-main-menu.png"
+  - "gallery/03-blinky-config-text-line.png"
+


### PR DESCRIPTION
# Application Submission

- This application turns the FlipBoard MacroPad into a blinky badge!  See https://youtu.be/z0cV6lG5wxc?t=151 for TalkingSasquach demo of the older version of the FlipBlinky application.

# Extra Requirements 

- This application requires the FlipBoard hardware accessory from MakeItHackin; which is available on tindie and Etsy.  The FlipBoard is a 4 button MacroPad with a colorful LED connected to each button.  Ordering directions can be found in the readme or by scanning the QR code in the application.
- I recommend the FlipBoard, but if you want to make something similar... use 4 WS2812B LEDs connected in a chain, with the data-in of the first LED going to PC3.  The switches are on PA6, PA4, PB3, PB2.  The status LED is on PA7.

# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
