### PR TITLE
Flipboard_Keyboard v3.6

### DIFF
--- a/applications/GPIO/flipboard_keyboard/manifest.yml
+++ b/applications/GPIO/flipboard_keyboard/manifest.yml
@@ -1,0 +1,16 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/jamisonderek/flipboard.git
+    commit_sha: 57b45694ac8439ce5bc62da6c7f73cc6ee85e7eb
+    subdir: flipkeyboard
+description: "@./gallery/README.md"
+changelog: "@./gallery/CHANGELOG.md"
+author: "CodeAllNight (MrDerekJamison)"
+screenshots:
+  - "gallery/07-key-splash.png"
+  - "gallery/04-key-config-3.png"
+  - "gallery/06-key-keyboard.png"
+  - "gallery/03-key-config-1.png"
+  - "gallery/04-key-config-2.png"
+  - "gallery/08-key-qrcode.png"


### PR DESCRIPTION
# Application Submission

- This application turns the FlipBoard MacroPad into a USB/BLE keyboard!  Each button (or button combination) on the MacroPad will send keystrokes via the USB or BLE (if USB cable is not connected) keyboard.  It will also play different tones, so you can use it as a musical keyboard as well.

See https://youtu.be/z0cV6lG5wxc?t=345 for TalkingSasquach demo of the older version of the FlipKeyboard application.
See https://www.youtube.com/shorts/LmEUcI4w4QQ for demo of playing a song with older version of the application.


# Extra Requirements 

- This application requires the FlipBoard hardware accessory from MakeItHackin; which is available on tindie and Etsy.  The FlipBoard is a 4 button MacroPad with a colorful LED connected to each button.  Ordering directions can be found in the readme or by scanning the QR code in the application.
- I recommend the FlipBoard, but if you want to make something similar... use 4 WS2812B LEDs connected in a chain, with the data-in of the first LED going to PC3.  The switches are on PA6, PA4, PB3, PB2.  The status LED is on PA7.

# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
