### PR TITLE
FlipBoard Signal v3.10

### DIFF
--- a/applications/GPIO/flipboard_signal/manifest.yml
+++ b/applications/GPIO/flipboard_signal/manifest.yml
@@ -1,0 +1,15 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/jamisonderek/flipboard.git
+    commit_sha: c6176ac0fa395867432aed4a83d190cb98bb65b9
+    subdir: flipsignal
+description: "@./gallery/README.md"
+changelog: "@./gallery/CHANGELOG.md"
+author: "CodeAllNight (MrDerekJamison)"
+screenshots:
+  - "gallery/05-signal-splash.png"
+  - "gallery/03-signal-config-1.png"
+  - "gallery/04-signal-sending.png"
+  - "gallery/01-signal-main-menu.png"
+  - "gallery/06-signal-qrcode.png"


### PR DESCRIPTION
# Application Submission

- This application turns the FlipBoard MacroPad into a Sub-GHz/IR remote!  Each button (or button combination) on the MacroPad will send a Sub-GHz signal (if configured) and then a set of Infrared codes (if configured).

See https://youtu.be/z0cV6lG5wxc?st=425 for TalkingSasquach demo of the older version of the FlipSignal application.
See https://youtu.be/uDaISCAcKpk for demo of both Sub-GHz and IR sequences.

# Extra Requirements 

- This application requires the FlipBoard hardware accessory from MakeItHackin; which is available on tindie and Etsy.  The FlipBoard is a 4 button MacroPad with a colorful LED connected to each button.  Ordering directions can be found in the readme or by scanning the QR code in the application.
- I recommend the FlipBoard, but if you want to make something similar... use 4 WS2812B LEDs connected in a chain, with the data-in of the first LED going to PC3.  The switches are on PA6, PA4, PB3, PB2.  The status LED is on PA7.


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
