### PR TITLE
FlipBoard Keyboard v3.7

### DIFF
--- a/applications/GPIO/flipboard_keyboard/manifest.yml
+++ b/applications/GPIO/flipboard_keyboard/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/jamisonderek/flipboard.git
-    commit_sha: 57b45694ac8439ce5bc62da6c7f73cc6ee85e7eb
+    commit_sha: 4daf338df314c3a86cf1c7a32d55893b09cef323
     subdir: flipkeyboard
 description: "@./gallery/README.md"
 changelog: "@./gallery/CHANGELOG.md"


### PR DESCRIPTION
# Application Submission

This is an updated application for the FlipBoard Keyboard application.  The difference between version 3.7 and 3.6 is that it has a bug fix where a memory address that wasn't allocated was getting freed, which sometimes caused a crash on application exit.

# Extra Requirements 

- This application requires the FlipBoard hardware accessory from MakeItHackin; which is available on tindie and Etsy.  The FlipBoard is a 4 button MacroPad with a colorful LED connected to each button.  Ordering directions can be found in the readme or by scanning the QR code in the application.
- I recommend the FlipBoard, but if you want to make something similar... use 4 WS2812B LEDs connected in a chain, with the data-in of the first LED going to PC3.  The switches are on PA6, PA4, PB3, PB2 (and connect to GND momentarily when pressed - ideally via 220 ohm resistor).  The status LED is on PA7.

# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
