### PR TITLE
Added HC-11 wireless modem emulator app manifest

### DIFF
--- a/applications/Sub-GHz/hc11_modem/manifest.yml
+++ b/applications/Sub-GHz/hc11_modem/manifest.yml
@@ -1,0 +1,16 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Giraut/flipper_zero_hc11_wireless_modem
+    commit_sha: d41d4f21da3dbe33915e1631b2d70fa2eb34c1d9
+short_description: HC-11 wireless modem
+description: "HC-11 wireless modem emulator for the Flipper Zero"
+changelog: "@Changelog.md"
+screenshots:
+  - screenshots/1-splash_version.png
+  - screenshots/2-usb_serial_passthrough1.png
+  - screenshots/3-usb_serial_passthrough2.png
+  - screenshots/4-app_description.png
+  - screenshots/5-configuration_menu.png
+  - screenshots/6-main_menu.png
+  - screenshots/7-warning.png


### PR DESCRIPTION
# Application Submission

- HC-11 wireless modem emulator for the Flipper Zero.

  The app relays USB serial data to/from a HC-11 module wirelessly on 444.4 → 439.0 MHz.
  
  This is the first release.


# Extra Requirements 

- A [HC-11 wireless RF UART communication module](https://www.hc01.com/goods/640e91920be12d0114404c98) from [HC-Tech](https://www.hc01.com/). This module is not sold directly by HC-Tech but available from distributors around the world. Documentation of the module in English [here](https://www.elecrow.com/download/HC-11.pdf).


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
