### PR TITLE
New app: NFC URL

### DIFF
--- a/applications/NFC/nfcurl/manifest.yml
+++ b/applications/NFC/nfcurl/manifest.yml
@@ -1,0 +1,11 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/y-dejong/nfcurl.git
+    commit_sha: 1e243e49e6c8f60f7094d52e5ed5914b4323d29a
+changelog: "@./docs/changelog.md"
+description: "@./docs/description.md"
+screenshots:
+  - screenshots/enter-url.png
+  - screenshots/emulate.png
+  - screenshots/options.png


### PR DESCRIPTION
# Application Submission

[NFC URL](https://github.com/y-dejong/nfcurl) is a simple application to generate NFC Tags from a URL.

Features:
- Generate http(s), (s)ftp, mailto, etc. URLs
- Save a list of URLs for later use
- Export to a Flipper NFC Tag file (.nfc)

# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
