### PR TITLE
Digimon F-Com v1.4 (Initial application)

### DIFF
--- a/applications/GPIO/fcom/README.md
+++ b/applications/GPIO/fcom/README.md
@@ -1,0 +1,3 @@
+## Status
+
+[![fcom](https://catalog.flipperzero.one/application/fcom/widget)](https://catalog.flipperzero.one/application/fcom/page)

--- a/applications/GPIO/fcom/manifest.yml
+++ b/applications/GPIO/fcom/manifest.yml
@@ -1,0 +1,14 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/TylerWilley/flipper-f-com
+    commit_sha: 5e2bca74648da90148495da86917a7e82027dc33
+id: "fcom"
+category: "GPIO"
+short_description: "App for interacting with digimon virtual pets"
+description: "@.catalog/README.md"
+changelog: "@.catalog/changelog.md"
+screenshots:
+  - ".catalog/screenshots/fcom-topmenu.png"
+  - ".catalog/screenshots/fcom-digiroms.png"
+  - ".catalog/screenshots/fcom-sendcode.png"

--- a/applications/GPIO/fcom/manifest.yml
+++ b/applications/GPIO/fcom/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/TylerWilley/flipper-f-com
-    commit_sha: 5e2bca74648da90148495da86917a7e82027dc33
+    commit_sha: 3269702e5949680e9d71554c92c5962d83228723
 id: "fcom"
 category: "GPIO"
 short_description: "App for interacting with digimon virtual pets"


### PR DESCRIPTION
# Application Submission

Digimon F-Com is an application used to connect to Digimon Virtual Pet devices. Digimon virtual pets have a 2 or 3 prong bus that they use to communicate for the purposes of transferring a pet from one device to another, battling, or evolving. Digimon F-Com can act as passthrough serial device so that an Android, iPhone, or computer applications can drive the interactions or it can drive them itself from files the user places on the device.


# Extra Requirements 

A voltage divider circuit (as described in the application repository) is required to convert the flipper's 3.3v signal to the (roughly) 2.7v the virtual pets use 


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
