### PR TITLE
Flipboard Signal 3.11

### DIFF
--- a/applications/GPIO/flipboard_signal/manifest.yml
+++ b/applications/GPIO/flipboard_signal/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/jamisonderek/flipboard.git
-    commit_sha: c6176ac0fa395867432aed4a83d190cb98bb65b9
+    commit_sha: b2e0374a4c2b4451d9d39a5fbc4eb08bb0280b98
     subdir: flipsignal
 description: "@./gallery/README.md"
 changelog: "@./gallery/CHANGELOG.md"


### PR DESCRIPTION
# Application Submission

- This version has a bug fix for hanging issue on newer frameworks. Freeing the popup resources was causing a hang later on, the fix is to free the popup at application exit.


# Extra Requirements 

- This version still requires a FlipBoard or similar GPIO hardware. Reproducing the hang on new firmware prior to the fix (does not require hardware) was: Launch app, wait for popup to be dismissed, About page, press down button 4 times, application would hang.


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
