### PR TITLE
fmf_to_sub v1.0

### DIFF
--- a/applications/Sub-GHz/fmf_to_sub/manifest.yml
+++ b/applications/Sub-GHz/fmf_to_sub/manifest.yml
@@ -1,0 +1,16 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/jamisonderek/flipper-zero-tutorials.git
+    commit_sha: 34095cf003d14a0b3d9949581867f8514414c7b2
+    subdir: subghz/fmf_to_sub
+description: "@./gallery/README.md"
+changelog: "@./gallery/CHANGELOG.md"
+author: "CodeAllNight (MrDerekJamison)"
+screenshots:
+  - "gallery/00-main-menu.png"
+  - "gallery/01-about1.png"
+  - "gallery/02-about2.png"
+  - "gallery/03-configure.png"
+  - "gallery/04-convert.png"
+  - "gallery/05-file.png"


### PR DESCRIPTION
# Application Submission

- This application converts Flipper music files into Sub-GHz files, which can then be heard by radios or Flipper Zero devices.
- Input files: Flipper Music Format (.FMF) or compatible comma delimited text (.TXT)
- Output file: Flip##.sub (Sub-GHz RAW file format).

# Extra Requirements 

- No hardware is required.  The files written are optimized for the "Flipboard Signal" application, but you can use the "Sub-GHz" application to send the files too.


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
