### PR TITLE
New App: T5577 Raw Writer v1.2

### DIFF
--- a/applications/RFID/t5577_writer/manifest.yml
+++ b/applications/RFID/t5577_writer/manifest.yml
@@ -1,0 +1,15 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/zinongli/T5577_Raw_Writer.git
+    commit_sha: 96fd8e8f3495bfbe2ce7cd65760d1e5eeba80115
+description: "@README.md"
+changelog: "@CHANGELOG.md"
+author: "Torron"
+screenshots:
+  - "screenshots/main_menu.png"
+  - "screenshots/config_1.png"
+  - "screenshots/config_2.png"
+  - "screenshots/writing.png"
+  - "screenshots/load.png"
+  - "screenshots/about.png"


### PR DESCRIPTION
# Application Submission

- This app allows user to write raw data onto T5577 fobs. 
- This app allows user to configure that T5577's modulation, RF clock, and user block number. 
- This app allows user to edit raw block data on Flipper Zero using the byte input interface.
- This app can save and load raw T5577 files in .t5577 Flipper format. Example [here](https://github.com/zinongli/T5577_Raw_Writer/blob/main/examples/Tag_1.t5577).
- [Repo](https://github.com/zinongli/T5577_Raw_Writer)


# Extra Requirements 

- Nothing needed. Every function can be achieved with a Flipper Zero.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
