### PR TITLE
GPIO: pokemon: bump to 2.1

### DIFF
--- a/applications/GPIO/pokemon/manifest.yml
+++ b/applications/GPIO/pokemon/manifest.yml
@@ -1,8 +1,8 @@
 sourcecode:
   type: git
   location:
-    origin: https://github.com/EstebanFuentealba/Flipper-Zero-Game-Boy-Pokemon-Trading
-    commit_sha: 282237f7ce9796c395eaadc06f8a86c8c562e405
+    origin: https://github.com/kbembedded/Flipper-Zero-Game-Boy-Pokemon-Trading
+    commit_sha: abeb8b126c598e7f2daaf3343507eb70b91b93e4
 description: "@README_catalog.md"
 changelog: "@changelog.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

- Add ability to reset trade state without affecting currently configured Pokemon

Ownership of the repo was transferred to me which is why the github URL has changed.


# Extra Requirements 

- GPIO connection to Game Boy via link cable
- Gen I or II Pokemon game


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
