### PR TITLE
genie recorder v3.1

### DIFF
--- a/applications/Sub-GHz/genie_record/manifest.yml
+++ b/applications/Sub-GHz/genie_record/manifest.yml
@@ -1,0 +1,19 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/jamisonderek/flipper-zero-tutorials.git
+    commit_sha: bd21796c034ed76738fa71bacb83cb099ad6f559
+    subdir: subghz/apps/genie-recorder
+description: "@./.flipcorg/gallery/README.md"
+changelog: "@./.flipcorg/gallery/CHANGELOG.md"
+author: "CodeAllNight (MrDerekJamison)"
+screenshots:
+  - ".flipcorg/gallery/01-about.png"
+  - ".flipcorg/gallery/02-learn-done.png"
+  - ".flipcorg/gallery/03-send-some-codes.png"
+  - ".flipcorg/gallery/04-main-menu.png"
+  - ".flipcorg/gallery/05-config.png"
+  - ".flipcorg/gallery/06-config-genie-file.png"
+  - ".flipcorg/gallery/07-learn-codes.png"
+  - ".flipcorg/gallery/08-send-new.png"
+  - ".flipcorg/gallery/09-send-complete.png"


### PR DESCRIPTION
# Application Submission

- This application allows you to clone a Genie remote control using GPIO to press the button on the remote 65536 times.
- Once a remote is cloned, you can use the Flipper Zero to send signals.


# Extra Requirements 

- You need a genie remote control connected to GPIO to capture the remote.
- You can also copy the "007f1991.gne" file from the repo into your "apps_data/genie" folder and then load the file from the Config setting.


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
