### PR TITLE
GPIO: flipper_gb_printer: bump to v0.2

### DIFF
--- a/applications/GPIO/flipper_gb_printer/manifest.yml
+++ b/applications/GPIO/flipper_gb_printer/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/kbembedded/flipper-gb-printer/
-    commit_sha: 8179265a47b8575a88cd377111a51a571fca40f1
+    commit_sha: 0d0ac6930f8c6e1861ef4a243a98fe8ff9a920b4
 description: "@.assets/README_catalog.md"
 changelog: "@changelog.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

- Adds support for capturing zero margin prints as a single image (this is the same process a real printer uses to print out an infinitely tall image).
- Handling of images of different heights (up to the max 144px).
- Adds pinout selection to support more interfaces.

# Extra Requirements 

- Game Boy, Link Cable interface to Flipper, Game Boy game that has Game Boy Printer support.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
