### PR TITLE
Add FlipStore v0.8 (changed to use Flipper Catalog API)

### DIFF
--- a/applications/GPIO/flip_store/manifest.yml
+++ b/applications/GPIO/flip_store/manifest.yml
@@ -2,13 +2,13 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/jblanked/FlipStore.git
-    commit_sha: 4d2a289721bb7c42f5daa55e820a036dfecbc7ae
+    commit_sha: 376da75952ca38f70e5505814bedca15c59690de
 short_description: "Download apps via WiFi directly to your Flipper Zero."
 description: "@./assets/README.md"
 changelog: "@./assets/CHANGELOG.md"
 author: "JBlanked"
 name: "FlipStore"
-version: "0.6"
+version: "0.7.2"
 id: "flip_store"
 category: "GPIO"
 targets: ['all']

--- a/applications/GPIO/flip_store/manifest.yml
+++ b/applications/GPIO/flip_store/manifest.yml
@@ -1,0 +1,20 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/jblanked/FlipStore.git
+    commit_sha: 0d506057ab9f96d860ea7c252ae3e204d4e9dffa
+short_description: "Download apps via WiFi directly to your Flipper Zero."
+description: "@./assets/README.md"
+changelog: "@./assets/CHANGELOG.md"
+author: "JBlanked"
+name: "FlipStore"
+version: "0.3"
+id: "flip_store"
+category: "GPIO"
+targets: ['all']
+icon: "app.png"
+screenshots:
+  - "assets/01-main-menu.png"
+  - "assets/02-catalog.png"
+  - "assets/03-list.png"
+  - "assets/04-success.png"

--- a/applications/GPIO/flip_store/manifest.yml
+++ b/applications/GPIO/flip_store/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/jblanked/FlipStore.git
-    commit_sha: 0d506057ab9f96d860ea7c252ae3e204d4e9dffa
+    commit_sha: 4966c64d68650e23af9f1f8361f3a1938ca767af
 short_description: "Download apps via WiFi directly to your Flipper Zero."
 description: "@./assets/README.md"
 changelog: "@./assets/CHANGELOG.md"

--- a/applications/GPIO/flip_store/manifest.yml
+++ b/applications/GPIO/flip_store/manifest.yml
@@ -2,19 +2,20 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/jblanked/FlipStore.git
-    commit_sha: 4966c64d68650e23af9f1f8361f3a1938ca767af
+    commit_sha: 4d2a289721bb7c42f5daa55e820a036dfecbc7ae
 short_description: "Download apps via WiFi directly to your Flipper Zero."
 description: "@./assets/README.md"
 changelog: "@./assets/CHANGELOG.md"
 author: "JBlanked"
 name: "FlipStore"
-version: "0.3"
+version: "0.6"
 id: "flip_store"
 category: "GPIO"
 targets: ['all']
 icon: "app.png"
 screenshots:
   - "assets/01-main-menu.png"
+  - "assets/05-browse.png"
   - "assets/02-catalog.png"
   - "assets/03-list.png"
   - "assets/04-success.png"

--- a/applications/GPIO/flip_store/manifest.yml
+++ b/applications/GPIO/flip_store/manifest.yml
@@ -2,13 +2,13 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/jblanked/FlipStore.git
-    commit_sha: 376da75952ca38f70e5505814bedca15c59690de
+    commit_sha: 3e3e525884e5ea87a6ed36b80d00f77da755f951
 short_description: "Download apps via WiFi directly to your Flipper Zero."
 description: "@./assets/README.md"
 changelog: "@./assets/CHANGELOG.md"
 author: "JBlanked"
 name: "FlipStore"
-version: "0.7.2"
+version: "0.8"
 id: "flip_store"
 category: "GPIO"
 targets: ['all']


### PR DESCRIPTION
# Application Submission

v0.8
- Updated FlipperHTTP to the latest library.
- Switched to use Flipper catalog API.
- Added an option to download Video Game Module firmware (FlipperHTTP)
- Added an option to download Github repositories.
- Updated Marauder to the version 1.2

v0.7.2
- Final memory allocation improvements

v0.7.1
- Improved memory allocation
- Fixed a crash when re-entering the same app list

v0.7
- Improved memory allocation
- Added updates from Derek Jamison

v0.6
- Updated app layout
- Added an option to download Developer Board firmware (Black Magic, FlipperHTTP, and Marauder)

v0.5
- Added app descriptions and versioning

v0.4
- Added an option to delete apps
- Edits by Willy-JL

v0.3
- Edits by Willy-JL
- Improved memory allocation
- Stability patch

Thanks to Willy, now we're using the major and minor API versions from `furi_hal_info_get_api_version` and target from `furi_hal_version_get_hw_target`

# Extra Requirements 

- WiFi Dev Board for Flipper Zero with FlipperHTTP Flash: https://github.com/jblanked/FlipperHTTP
- WiFi Access Point


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
