### PR TITLE
add canfdhs app

### DIFF
--- a/applications/GPIO/canfdhs/README.md
+++ b/applications/GPIO/canfdhs/README.md
@@ -1,0 +1,97 @@
+# Flipper Zero CAN FD HS SW
+
+
+This software implements an USB to CAN bridge compatible with **Linux [can-utils](https://github.com/linux-can/can-utils) and slcan driver.** <br>
+This software application is designed to run on flipper zero device and needs SERMA CAN FD board to be plugged in GPIOs ports available [here](https://github.com/serma-safety-security/flipper-zero-can-fd-hs-module).<br>
+![Flipper zero CAN FD](./Documentation/images/main_logo.png "Flipper zero CAN FD")
+
+## Usage
+
+When entering the application (by selecting can-fd-hs) from main menu or by selecting Apps/USB-CAN, a list appears with 3 choices which represent the 3 modes of the application detailled in next sections :
+- **USB-CAN Bridge :** This is the **main mode** which is used as a bridge between can-utils and a CAN device under test. 
+- TEST USB LOOPBACK : This mode is used to test connectivity between host computer and flipper zero.
+- CAN TEST : This mode is used to test CAN connectivity. This send "CANALIVE" through CAN.
+
+### USB-CAN Bridge
+
+This mode have to be entered before issuing any configuration command.
+Then you can :
+1. Create a CAN network interface through USB Virtual com port (VCP) :`sudo slcand -s<X> <options> ttyACM<Y> can<Z>`.
+2. enable your created network interface `sudo ifconfig can<X> up`.
+3. operate normally your can interface by using `cansend can<X> <iii>#<dddddddd>` and `candump can<X>` commands.
+
+Please refer to [can-utils](https://github.com/linux-can/can-utils) for more details.<br>
+If issues are encountered, you can get more informations by connecting directly to vcp with tool like putty :
+- serial mode
+- 8 data bits
+- no parity
+- no hardware control flow
+
+You can see the following screenshot for more informations:
+
+![debug mode](./Documentation/images/debug.png "debug mode")
+
+**This mode can also be used to configure connection in flexible datarate ("S9" command).**<br>
+
+> **NB1 : beware of command line termination. It must be a carriage return '\r'. For more convenience newline '\n' characters located after carriage returns are ignored.** <br>
+> **NB2 : for compatibility reason (with can-utils)  newline character is not appended after CAN RX frames.As a consequence display of these frames is impacted. To avoid this send "d" on VCP to enter in debug mode.** <br>
+> **NB3 : beware of usb cdc buffer length. Max size is 64. So command number that can be sent in one frame is limited.** <br>
+
+### TEST USB LOOPBACK
+
+This mode is used to test VCP (USB cdc) connectivity. To use this mode, you have to :
+1. connect to the VCP with any VCP tool like putty :
+    - serial mode
+    - 8 data bits
+    - no parity
+    - no hardware control flow
+2. Once the connection is established message USB loopback is displayed, the user can test connection by sending characters on serial line and checking the content sent is sent back on serial line by the flipper device.
+
+![USB loopback](./Documentation/images/usb_loopback.png "USB loopback")
+
+### TEST CAN
+
+This mode is used to test CAN connection (to verify wiring between CAN device under test and flipper zero board).
+No user action is required before using this mode (except the obvious wiring step).<br>
+The frame sent every 200 ms shall by the device shall be the following :
+- **007E5TCA:43414E4C49564500** : IIIIIIII:DDDDDDDDDDDDDDDD with 
+    - **\<III..\>** the extended identifier (007E57CA = "TESTCA" in hexspeak) 
+    - **\<DDD..\>** the data (43414E4C49564500 = "CANLIVE" in ascii).
+
+![test can](./Documentation/images/testcan.JPG "test can")
+
+> note : You can first check Tx LED blinks and transmitted byte counter (on flipper screen) increment by 8 every 200ms to diagnose problems.
+
+## Development
+
+### documentation
+
+Documentation can be found [here](./Documentation/html/index.html).\
+To re-generate documentation you have to install `doxygen` before running `Documentation/generate_doc.sh [--open]` (--open is used to open documentation after the generation). 
+
+
+### architecture overview
+
+This application is based on:
+- XTREME firmware USB-UART bridge application : It has been modified to send data on CAN (via SPI) and not on UART.
+- Longan Labs [Longan_CANFD](https://github.com/Longan-Labs/Longan_CANFD) library : this is the driver for the MCP 2518 CAN transceiver.
+
+**More information on architecture is given in [docs](./Documentation/html/index.html) (cf. previous section).**
+
+Application is built as an external app using standard fbt commands. Please refer to flipper documentation for more information.
+
+### Test status
+Applications has been tested with a MCP2515 evaluation board. As a consequence, only the following datarates are tested :
+- 125 Kbaud
+- 250 Kbaud
+- 500 Kbaud
+- 1 MBaud
+
+![Flipper zero CAN FD test setup](./Documentation/images/CAN_test.png "Flipper zero CAN FD test setup")
+
+> **Note: the flexible datarate is not tested yet.**
+
+### Known bugs
+
+Multiple exit and enters in application and its submode produce instable behaviour.
+

--- a/applications/GPIO/canfdhs/manifest.yml
+++ b/applications/GPIO/canfdhs/manifest.yml
@@ -1,0 +1,21 @@
+## This is a sample manifest file for the Flipper Apps Catalog.
+## Create one for your app in a corresponding directory in the 'applications' folder.
+
+sourcecode:
+  type: git
+  location:
+    ## Specify the git URL of your repository
+    origin: https://github.com/serma-safety-security/Flipper-Zero-CAN-FD-HS-SW.git
+    ## Put the full commit SHA of the commit with the app's code you want to submit
+    commit_sha: 5c050f4f825957c44e3cd54bd784b8dfec9cdcdf  
+    ## (Optional) If your app is located in a subdirectory of the repository, specify it here
+    # subdir: .
+## If application.fam contains 'fap_description', it will be used as a short description
+short_description: This software implements an USB to CAN bridge compatible with Linux can-utils and slcan driver.
+## For 'description' and 'changelog', you can use limited markdown syntax
+## You can also specify a file from your app's repository as a source with @
+description:  "@Documentation/README_lite.md"
+changelog: "@changelog.md"
+## Unmodified screenshots from qFlipper
+screenshots:
+  - Documentation/qflipper_screenshots/Screenshot-1.png


### PR DESCRIPTION
# Application Submission

This software implements an USB to CAN bridge compatible with **Linux [can-utils](https://github.com/linux-can/can-utils) and slcan driver.** 


# Extra Requirements 

This software application is designed to run on flipper zero device and needs SERMA CAN FD board to be plugged in GPIOs ports available [here](https://github.com/serma-safety-security/flipper-zero-can-fd-hs-module).


# Author Checklist (Fill this out)

- [x ] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x ] I own the code I'm submitting or have code owner's permission to submit it
- [x ] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
