### PR TITLE
Bump flipperscope to v0.4

### DIFF
--- a/applications/GPIO/flipperscope/manifest.yml
+++ b/applications/GPIO/flipperscope/manifest.yml
@@ -2,9 +2,12 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/anfractuosity/flipperscope.git
-    commit_sha: 34787516d386a0c2962c6fbee13639375b6974c5
+    commit_sha: 48ec8e2ecc6d88cdcad21a742676994ec1a04da4
 description: "@./docs/README.md"
 changelog: "@./docs/CHANGELOG.md"
 screenshots:
   - "./screenshots/freq.png"
   - "./screenshots/volt.png"
+  - "./screenshots/fft.png"
+  - "./screenshots/capture.png"
+  - "./screenshots/setup.png"


### PR DESCRIPTION
# Application Submission

Added simple spectrum analyser

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

Unfortunately I'm not able to validate using bundle.py, as I'm using python 3.13, where _create_fn has been removed from dataclasses, so the script doesn't run correctly any more.

# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
