### PR TITLE
GPIO/flipper_gb_printer: bump to v0.4

### DIFF
--- a/applications/GPIO/flipper_gb_printer/manifest.yml
+++ b/applications/GPIO/flipper_gb_printer/manifest.yml
@@ -2,10 +2,11 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/kbembedded/flipper-gb-printer/
-    commit_sha: 0d0ac6930f8c6e1861ef4a243a98fe8ff9a920b4
+    commit_sha: 20d3322ee424a813f03aefeaa76b2532d38fd34e
 description: "@.assets/README_catalog.md"
 changelog: "@changelog.md"
 screenshots:
+  - ".assets/fgp-recv.png"
   - ".assets/fgp-mainmenu.png"
   - ".assets/fgp-recvconfig.png"
-  - ".assets/fgp-recv.png"
+  - ".assets/fgp-pinconf.png"


### PR DESCRIPTION
# Application Submission

- Move pinout selection to main menu
- Update to improved pinout configuration handling w/ auto-save and auto-load pinouts
- Add fine grained save options
- Shift to new naming scheme. Files still placed in dated folder, will have date in output file name(s), as well as a globally incrementing (as opposed to reset each day) 4 digit number.

# Extra Requirements 

Flipper, Game Boy, Link Cable interface, Game Boy game capable of printing.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
