### PR TITLE
GPIO/pokemon: bump to v2.3

### DIFF
--- a/applications/GPIO/pokemon/manifest.yml
+++ b/applications/GPIO/pokemon/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/kbembedded/Flipper-Zero-Game-Boy-Pokemon-Trading
-    commit_sha: 3ea38b0b1548378127fc0b455939b854546fa23a
+    commit_sha: 8769074c727ef3fa2da83e30daaf1aa964349c7e
 description: "@README_catalog.md"
 changelog: "@changelog.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

Fixes datatype casting issue that could result in weirdness in Gen II trades.


# Extra Requirements 

- Gen II pokemon game, Game Boy that can play it, Flipper link cable interface


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
