### PR TITLE
Add tamagometer_companion v0.2

### DIFF
--- a/applications/Infrared/tamagometer_companion/manifest.yml
+++ b/applications/Infrared/tamagometer_companion/manifest.yml
@@ -1,0 +1,16 @@
+sourcecode:
+  type: git
+  location:
+    ## Specify the git URL of your repository
+    origin: https://github.com/zacharesmer/tamagometer-companion-flipper.git
+    ## Put the full commit SHA of the commit with the app's code you want to submit
+    commit_sha: f0e7d032c848d3c42096564d132bc333010bcd02
+    ## (Optional) If your app is located in a subdirectory of the repository, specify it here
+    # subdir: .
+## For 'description' and 'changelog', you can use limited markdown syntax
+## You can also specify a file from your app's repository as a source with @
+description: "@description.md"
+changelog: "@CHANGELOG.md"
+## Unmodified screenshots from qFlipper
+screenshots:
+  - screenshots/screenshot1.png


### PR DESCRIPTION
# Application Submission

- Tamagometer Companion lets a computer use the Flipper's IR capabilities to communicate with a Tamagotchi Connection (2024 version). It's designed to work with a web app I made (hosted on Github pages [here](https://zacharesmer.github.io/tamagometer/))
- It works by adding a `tamagometer` CLI command to the Flipper CLI while the app is open, and the tamagometer website calls that command using the Web Serial API. The GUI doesn't do anything but keep the app open.

# Extra Requirements 

- A computer with a serial connection to the Flipper, and a Chromium browser connected to the tamagometer web app. You could run the command to listen for or send Tamagotchi signals in minicom or something if you really wanted to, but the tamagometer web app allows for two way communication so you can actually start visits, send gifts, and play games.
- A Tamagotchi Connection 2024 version. I plan to add support for other versions of Tamagotchi that use IR once I have studied them more.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
