### PR TITLE
Update Lightmeter v1.3

### DIFF
--- a/applications/GPIO/lightmeter/manifest.yml
+++ b/applications/GPIO/lightmeter/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/oleksiikutuzov/flipperzero-lightmeter
-    commit_sha: 13b958b07eb21813680bca39923151364f035daf
+    commit_sha: 671723ddba0eb8f0089fcd2e9901e0a535bb8724
     subdir: application
 description: "@./docs/README.md"
 changelog: "@./docs/changelog.md"


### PR DESCRIPTION
# Application Submission

- Update Exposure Value compute logic
- Remove deprecated view_dispatcher_enable_queue call

# Extra Requirements 

- none


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
