### PR TITLE
Sub-GHz Scheduler v2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 __pycache__
 .DS_Store
 *.zip
+/test.bat

--- a/applications/Infrared/xbox_controller/manifest.yml
+++ b/applications/Infrared/xbox_controller/manifest.yml
@@ -1,10 +1,10 @@
 sourcecode:
   type: git
   location:
-    origin: https://github.com/gebeto/flipper-xbox-controller.git
-    commit_sha: 5bd4ed2e9664dea667be2163e2157b19ca60c0b0
-description: "Infrared remote control for Xbox One"
-changelog: "v1.1 - Stable release, v1.2 - Fix build for latest firmware"
+    origin: https://github.com/gebeto/flipper-xbox-controller
+    commit_sha: f4809a69e06cb3de2331351226f6cb2382ce7bfa
+description: "@./docs/README.md"
+changelog: "@./docs/changelog.md"
 author: "@gebeto"
 screenshots:
   - "./img/screenshot.png"

--- a/applications/Sub-GHz/subghz_scheduler/manifest.yml
+++ b/applications/Sub-GHz/subghz_scheduler/manifest.yml
@@ -2,9 +2,8 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/shalebridge/flipper-subghz-scheduler.git
-    commit_sha: 89657adbacd407c4e29c2b11ea584103bb5127f6
-    subdir: subghz_scheduler
-description: "@README.md"
+    commit_sha: e70d903b6d1111e35e4a3e3d0b8756d0318fdaed
+description: "A Flipper Zero app to send SubGHz signals at a given interval. Individual *.sub or playlist *.txt files can be used. Discrete intervals from 10 seconds to 12 hours are selectable, as well as repeating transmissions for individual data."
 changelog: "@CHANGELOG.md"
 author: "@shalebridge"
 screenshots:

--- a/applications/Sub-GHz/subghz_scheduler/manifest.yml
+++ b/applications/Sub-GHz/subghz_scheduler/manifest.yml
@@ -2,10 +2,10 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/shalebridge/flipper-subghz-scheduler.git
-    commit_sha: e70d903b6d1111e35e4a3e3d0b8756d0318fdaed
+    commit_sha: 2813ac6adbabce4281d2cbfc9baa06a95261724c
 name: "Sub-GHz Scheduler"
 id: "subghz_scheduler"
-version: "1.0"
+version: "2.0"
 description: "A Flipper Zero app to send SubGHz signals at a given interval. Individual *.sub or playlist *.txt files can be used. Discrete intervals from 10 seconds to 12 hours are selectable, as well as repeating transmissions for individual data."
 short_description: "An app to send a SUB or playlist file repeatedly at a given interval."
 changelog: "@CHANGELOG.md"
@@ -14,6 +14,6 @@ targets: ['all']
 category: "Sub-GHz"
 icon: "icons/icon.png"
 screenshots:
-  - "./screenshots/v0/s_10min_x1.png"
-  - "./screenshots/v0/pl_1min_x3.png"
-  - "./screenshots/v0/1_s_run_30sec_x3.png"
+  - "./screenshots/v2.0/a_run_view.png"
+  - "./screenshots/v2.0/10s_x1_tx250_norm.png"
+  - "./screenshots/v2.0/x3_tx250_oneshot.png"

--- a/applications/Sub-GHz/subghz_scheduler/manifest.yml
+++ b/applications/Sub-GHz/subghz_scheduler/manifest.yml
@@ -1,0 +1,13 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/shalebridge/flipper-subghz-scheduler.git
+    commit_sha: 89657adbacd407c4e29c2b11ea584103bb5127f6
+    subdir: subghz_scheduler
+description: "@README.md"
+changelog: "@CHANGELOG.md"
+author: "@shalebridge"
+screenshots:
+  - "./screenshots/v0/s_10min_x1.png"
+  - "./screenshots/v0/pl_1min_x3.png"
+  - "./screenshots/v0/1_s_run_30sec_x3.png"

--- a/applications/Sub-GHz/subghz_scheduler/manifest.yml
+++ b/applications/Sub-GHz/subghz_scheduler/manifest.yml
@@ -3,9 +3,16 @@ sourcecode:
   location:
     origin: https://github.com/shalebridge/flipper-subghz-scheduler.git
     commit_sha: e70d903b6d1111e35e4a3e3d0b8756d0318fdaed
+name: "Sub-GHz Scheduler"
+id: "subghz_scheduler"
+version: "1.0"
 description: "A Flipper Zero app to send SubGHz signals at a given interval. Individual *.sub or playlist *.txt files can be used. Discrete intervals from 10 seconds to 12 hours are selectable, as well as repeating transmissions for individual data."
+short_description: "An app to send a SUB or playlist file repeatedly at a given interval."
 changelog: "@CHANGELOG.md"
-author: "@shalebridge"
+author: "Patrick Edwards"
+targets: ['all']
+category: "Sub-GHz"
+icon: "icons/icon.png"
 screenshots:
   - "./screenshots/v0/s_10min_x1.png"
   - "./screenshots/v0/pl_1min_x3.png"


### PR DESCRIPTION
# Application Submission

- A Flipper Zero app to send SubGHz signals at a given interval. Individual *.sub or playlist *.txt files can be used. Discrete intervals from `10 seconds` to `12 hours` are selectable, as well as repeating transmissions for individual data.


# Extra Requirements 

- None


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
