### PR TITLE
Added longwave_clock v 0.1

### DIFF
--- a/applications/GPIO/longwave_clock/manifest.yml
+++ b/applications/GPIO/longwave_clock/manifest.yml
@@ -1,0 +1,15 @@
+author: "@m7i-org"
+category: "GPIO"
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/m7i-org/flipper_longwave_clock.git
+    commit_sha: 85317993287ae00334423d88cde220212e791732
+description: |
+  Receive long wave time signals through inexpensive GPIO modules, or simulate receipt if you don't own any.
+  Supports DCF77 as well as MSF, with more protocols to be implemented in the future.
+changelog: "@CHANGELOG.md"
+screenshots:
+  - screenshots/v0.1/big_dcf77.png
+  - screenshots/v0.1/big_msf.png
+  - screenshots/v0.1/big_menu.png


### PR DESCRIPTION
# Application Submission

- This app can receive long wave signals via GPIO modules
- Alternatively it can simulate reception if no modules are available
- Decoding the protocols is transparent in the graphical interface
- The decoded date/time is then constantly updated based on the incoming bits
- Supported are DCF77 and MSF reception.

# Extra Requirements 

- Optional: GPIO modules shown [in the homepage](https://github.com/m7i-org/flipper_longwave_clock). Otherwise, use simulation mode.


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
