### PR TITLE
lightmessenger integration

### DIFF
--- a/applications/GPIO/401_light_msg/manifest.yml
+++ b/applications/GPIO/401_light_msg/manifest.yml
@@ -1,0 +1,20 @@
+## LightMessenger - by Tixlegeek, brought to you by LAB401
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/lab-401/fzLightMessenger.git
+    commit_sha: fde9a73ec829929be4d5d9f49887ef6e775e2f6f
+    subdir: ./401lightMessengerApp
+short_description: LightMessenger's hardware companion.
+description: |
+  LightMessenger by Tixlegeek, and brought to you by LAB401 is a hardware module allowing to write and draw on the air using a 16 RGB Led array and an accelerometer.
+  You can write your own text and create or modify your own custom images, use it as a flashlight, and configure every aspect of your new fabulous toy.
+  Photobomb only when it's ok
+changelog: "@CHANGELOG.md"
+author: "@tixlegeek"
+screenshots:
+  - screenshots/sc01.png
+  - screenshots/sc02.png
+  - screenshots/sc03.png
+  - screenshots/sc04.png
+  - screenshots/sc05.png


### PR DESCRIPTION
# Application Submission

- Lab401's LightMessenger module companion, allowing users to draw text and images in the air using a 16 RGB Led array and an accelerometer. The app contains a bitmap drawing tool, a flashlight mode, configuration etc.


# Extra Requirements 

- This application needs a special opensource hardware called LightMessenger yet to be released.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
