### PR TITLE
Bump Portal of Flipper to v1.1

### DIFF
--- a/applications/USB/portal_of_flipper/manifest.yml
+++ b/applications/USB/portal_of_flipper/manifest.yml
@@ -6,5 +6,5 @@ screenshots:
 sourcecode:
   type: git
   location:
-    origin: https://gitlab.com/bettse/portal_of_flipper.git
-    commit_sha: 91e201a82d1702b9082a363f94635303ab667a98
+    origin: https://github.com/sanjay900/portal_of_flipper.git
+    commit_sha: 1dd84ba80c1e0ebf412218e756cc423a3abae0b5


### PR DESCRIPTION
# Application Submission

- Added support for xbox 360
- Added support for emulating the portals LEDs

# Extra Requirements 

-  Game console (non-xbox one)
-  Game (Skylanders: Giants, Skylanders: Trap Team, Skylanders: Superchargers)


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
