### PR TITLE
Add sio2flip v0.1

### DIFF
--- a/applications/GPIO/sio2flip/manifest.yml
+++ b/applications/GPIO/sio2flip/manifest.yml
@@ -1,0 +1,12 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/cepetr/sio2flip.git
+    commit_sha: efc92373c4ca7246463988f7424e11624c4e8ae6
+description: "@description.md"
+changelog: "@CHANGELOG.md"
+screenshots:
+  - "./screenshots/screenshot_fdd.png"
+  - "./screenshots/screenshot_xex_loader.png"
+  - "./screenshots/screenshot_app_config.png"
+  - "./screenshots/screenshot_fdd_config.png"


### PR DESCRIPTION
# Application Submission

sio2flip emulates SIO peripherals for Atari 8-bit computers, currently featuring floppy drive emulation and direct XEX executable loading.

# Extra Requirements 

- An Atari 8-bit computer (e.g., 800XL/XE, 130XE, or other compatible models)
- A wired connection between the Flipper and the Atari SIO connector
- One or more .atr or .xex files in the apps_data/sio2flip/ folder on your SD card


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
