### PR TITLE
Tools: Fix for Python 3.13

### DIFF
--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,4 @@
-dataclass-wizard==0.22.3
+dataclass-wizard==0.26.0
 Pillow==10.4.0
 PyYAML==6.0.2
 Markdown==3.7


### PR DESCRIPTION
Fixes #600 

there is also issue in fbt about `@classmethod` and `@property` being used together which will not work on 3.13, so app will not build correctly due to ufbt. i will make a pr for this in firmware repo shortly.