### PR TITLE
Updated hc11_modem to 1.2

### DIFF
--- a/applications/Sub-GHz/hc11_modem/manifest.yml
+++ b/applications/Sub-GHz/hc11_modem/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Giraut/flipper_zero_hc11_wireless_modem
-    commit_sha: cddf9dab43daa51743dd29d97d6ad771ddfbb26c
+    commit_sha: d3a02c89eabe43ef75a47af22f325a1e8d93e5c1
 short_description: HC-11 wireless modem
 description: "HC-11 wireless modem emulator for the Flipper Zero"
 changelog: "@Changelog.md"

--- a/applications/Sub-GHz/hc11_modem/manifest.yml
+++ b/applications/Sub-GHz/hc11_modem/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Giraut/flipper_zero_hc11_wireless_modem
-    commit_sha: d3a02c89eabe43ef75a47af22f325a1e8d93e5c1
+    commit_sha: 043c1454c69c101162789576cd689a1325f3f970
 short_description: HC-11 wireless modem
 description: "HC-11 wireless modem emulator for the Flipper Zero"
 changelog: "@Changelog.md"


### PR DESCRIPTION
# Application Submission

- HC-11 wireless modem emulator for the Flipper Zero.

  New in version 1.2:

    - Made passthru.c work with cli_vcp_disable() / cli_vcp_enable() when applicable (firmware 1.3.2-rc)

# Extra Requirements 

- A [HC-11 wireless RF UART communication module](https://www.hc01.com/goods/640e91920be12d0114404c98) from [HC-Tech](https://www.hc01.com/). This module is not sold directly by HC-Tech but available from distributors around the world. Documentation of the module in English [here](https://www.elecrow.com/download/HC-11.pdf).


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
