### PR TITLE
Update sio2flip to v0.2

### DIFF
--- a/applications/GPIO/sio2flip/manifest.yml
+++ b/applications/GPIO/sio2flip/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/cepetr/sio2flip.git
-    commit_sha: efc92373c4ca7246463988f7424e11624c4e8ae6
+    commit_sha: f9c3309e33f9f89957ef7d33162400d09e7227e5
 description: "@description.md"
 changelog: "@CHANGELOG.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

- Added Atari 850 modem emulation, with the serial connection bridged via USB CDC (virtual COM port).

# Extra Requirements 

- An Atari 8-bit computer (e.g., 800XL/XE, 130XE, or other compatible models)
- A wired connection between the Flipper and the Atari SIO connector
- One or more .atr or .xex files in the apps_data/sio2flip/ folder on your SD card

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
