### PR TITLE
Bump passy to 1.2

### DIFF
--- a/applications/NFC/passy/manifest.yml
+++ b/applications/NFC/passy/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/bettse/passy.git
-    commit_sha: 68ec04137545db662a6f5da222cfad0c213bd384
+    commit_sha: d3e921af6d965500da6ba6d455e66243422764f6
 description: "@.catalog/README.md"
 changelog: "@.catalog/changelog.md"
 author: "bettse"


### PR DESCRIPTION
# Application Submission

- Fixes crash when passport read only catches `NfcProtocolIso14443_3b`
- Fixes passports that have Q-Z in their passport number

# Extra Requirements 

- A passport with a Q-Z that was failing before should no longer fail


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
