### PR TITLE
github: pinned tj-actions/changed-files version with sha

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Get updated manifests
         id: changed-files
-        uses: tj-actions/changed-files@v44
+        uses: tj-actions/changed-files@ed68ef82c095e0d48ec87eccea555d944a631a4c
         with:
           files: |
             applications/**/manifest.yml


### PR DESCRIPTION
# Application Submission

- github: pinned tj-actions/changed-files version with sha to address recent CVE 


# Extra Requirements 

- no functional changes


- [x] There are no obvious issues with the source code
