### PR TITLE
iButton converter v1.0

### DIFF
--- a/applications/iButton/ibutton_converter/manifest.yml
+++ b/applications/iButton/ibutton_converter/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Leptopt1los/ibutton_converter.git
-    commit_sha: d1c87bdb4e9c8067dcb2e63405ded153e2674649
+    commit_sha: 5c00cadfd1781f4b8c412e603997071f43bc4c9c
 description: "@README.md"
 changelog: "@CHANGELOG.md"
 screenshots:

--- a/applications/iButton/ibutton_converter/manifest.yml
+++ b/applications/iButton/ibutton_converter/manifest.yml
@@ -1,0 +1,13 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Leptopt1los/ibutton_converter.git
+    commit_sha: 8fdfc6b1083a8503b9c3a50125389d528f03bc24
+description: "@README.md"
+changelog: "@CHANGELOG.md"
+screenshots:
+  - screenshots/main_menu_options.png
+  - screenshots/key_select.png
+  - screenshots/metakom_convert_options.png
+  - screenshots/cyfral_convert_options.png
+  - screenshots/save_success.png

--- a/applications/iButton/ibutton_converter/manifest.yml
+++ b/applications/iButton/ibutton_converter/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Leptopt1los/ibutton_converter.git
-    commit_sha: 8fdfc6b1083a8503b9c3a50125389d528f03bc24
+    commit_sha: d1c87bdb4e9c8067dcb2e63405ded153e2674649
 description: "@README.md"
 changelog: "@CHANGELOG.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

**iButton Converter** is a Flipper Zero application designed for converting iButton key dumps from *Metakom* or *Cyfral* formats into the *Dallas* format. The application supports multiple conversion modes for each format, including well-known and lesser-known encoding schemes.

## Features

- Support for importing Metakom and Cyfral key dump files
- Multiple conversion modes:
  - **Metakom**: 
    - `direct` mode
    - `reversed` mode
  - **Cyfral**:
    - Standard modes: `C1`, `C2`, `C3`, `C4`
    - Extended modes: `C5`, `C6`, `C7`
- Output to Dallas iButton format
- Custom naming for the converted output file

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
