### PR TITLE
Add Combo Cracker application

### DIFF
--- a/applications/Tools/combo_cracker/manifest.yml
+++ b/applications/Tools/combo_cracker/manifest.yml
@@ -1,0 +1,18 @@
+author: '@CharlesTheGreat77'
+category: 'Tools'
+description: '@./docs/README.md'
+changelog: '@./docs/CHANGELOG.md'
+icon: 'icons/app10x10.png'
+id: 'combo_cracker'
+name: 'Combo Cracker'
+screenshots:
+  - 'screenshots/screenshot1.png'
+  - 'screenshots/screenshot2.png'
+short_description: 'Crack combo locks in 8 attempts or less'
+sourcecode:
+  location:
+    commit_sha: c6b75dd1909ba2203f03faaa3a2113880f0a3c93
+    origin: https://github.com/CharlesTheGreat77/ComboCracker-FZ.git
+    subdir:
+  type: git
+version: 0.1


### PR DESCRIPTION
This utility assists in cracking combination pad locks by computing the necessary arithmetic to display the deduced combinations. 

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer
- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
