### PR TITLE
Add hitachi_ac_remote

### DIFF
--- a/applications/Infrared/hitachi_ac_remote/README.md
+++ b/applications/Infrared/hitachi_ac_remote/README.md
@@ -1,0 +1,3 @@
+## Status
+
+[![hitachi_ac_remote](https://catalog.flipperzero.one/application/hitachi_ac_remote/widget)](https://catalog.flipperzero.one/application/hitachi_ac_remote/page)

--- a/applications/Infrared/hitachi_ac_remote/manifest.yml
+++ b/applications/Infrared/hitachi_ac_remote/manifest.yml
@@ -1,0 +1,10 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/dogtopus/flipperzero-hitachi-ac-remote.git
+    commit_sha: 1524f03c3dd0f290c11b932cdc1557c9ca53de7d
+short_description: "Hitachi Air Conditioner remote control"
+description: "@./README_CATALOG.md"
+changelog: "@./CHANGELOG.md"
+screenshots:
+  - "./img/1.png"


### PR DESCRIPTION
# Application Submission

- Another hard fork of the [mitsubishi_ac_remote](https://github.com/achistyakov/flipperzero-mitsubishi-ac-remote) application. This time supporting Hitachi air conditioners.


# Extra Requirements 

- None


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
