### PR TITLE
Update hitachi_ac_remote to v1.1

### DIFF
--- a/applications/Infrared/hitachi_ac_remote/manifest.yml
+++ b/applications/Infrared/hitachi_ac_remote/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/dogtopus/flipperzero-hitachi-ac-remote.git
-    commit_sha: c88a0394a632a0d67ea8c6bf1b90e738a2e395fd
+    commit_sha: 4cbf740e7a1fd7036e93be2a42b7e6fa4a4cc956
 short_description: "Hitachi Air Conditioner remote controller"
 description: "@./README_CATALOG.md"
 changelog: "@./CHANGELOG.md"

--- a/applications/Infrared/hitachi_ac_remote/manifest.yml
+++ b/applications/Infrared/hitachi_ac_remote/manifest.yml
@@ -2,9 +2,11 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/dogtopus/flipperzero-hitachi-ac-remote.git
-    commit_sha: 1524f03c3dd0f290c11b932cdc1557c9ca53de7d
-short_description: "Hitachi Air Conditioner remote control"
+    commit_sha: c88a0394a632a0d67ea8c6bf1b90e738a2e395fd
+short_description: "Hitachi Air Conditioner remote controller"
 description: "@./README_CATALOG.md"
 changelog: "@./CHANGELOG.md"
 screenshots:
   - "./img/1.png"
+  - "./img/2.png"
+  - "./img/screenshot3.png"


### PR DESCRIPTION
# Application Submission

Update hitachi_ac_remote to v1.1, which implements all known features of the Hitachi PC-LH3 series remote.

# Extra Requirements 

- None

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
