### PR TITLE
Bump Metroflip to v0.8

### DIFF
--- a/applications/NFC/metroflip/manifest.yml
+++ b/applications/NFC/metroflip/manifest.yml
@@ -23,8 +23,8 @@ screenshots:
 short_description: 'An implementation of Metrodroid on the Flipper Zero'
 sourcecode:
   location:
-    commit_sha: 5630b5b6a385cceedd3edc75c6622c64baa71d34
+    commit_sha: 49360a2b7cacbb71a1033de3500227b82ac32bf5
     origin: https://github.com/luu176/Metroflip
     subdir:
   type: git
-version: 0.7
+version: 0.8

--- a/applications/NFC/metroflip/manifest.yml
+++ b/applications/NFC/metroflip/manifest.yml
@@ -23,7 +23,7 @@ screenshots:
 short_description: 'An implementation of Metrodroid on the Flipper Zero'
 sourcecode:
   location:
-    commit_sha: 49360a2b7cacbb71a1033de3500227b82ac32bf5
+    commit_sha: cd66200b052fcd3003102545ea5c636da1efab5d
     origin: https://github.com/luu176/Metroflip
     subdir:
   type: git


### PR DESCRIPTION
# Application Submission

- Metroflip v0.8 introduces support for 80+ new card AIDs.  
- Improved DESFire support with added AIDs and parsing fixes.  
- Added Calypso card saving functionality for easier backup and restoration.  
- Resolved multiple bugs, including issues with Calypso file saving, Clipper timestamp handling, and crashes related to Navigo cards.  
- Enhancements improve overall stability and card parsing accuracy.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
