### PR TITLE
Updated noptel_lrf_sampler to 2.3

### DIFF
--- a/applications/GPIO/noptel_lrf_sampler/manifest.yml
+++ b/applications/GPIO/noptel_lrf_sampler/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Giraut/flipper_zero_noptel_lrf_sampler
-    commit_sha: be61715e4144df8d00596591e00e51e871a44054
+    commit_sha: 591fe3113e9ea717f7dbc8425f87f30f6dc411a5
 short_description: Noptel LRF rangefinder sampler
 description: "Noptel LRF rangefinder sampler app for the Flipper Zero"
 changelog: "@Changelog.md"


### PR DESCRIPTION
# Application Submission

- Noptel LRF rangefinder sampler app

  New in version 2.3:

    - Added a function to test the rangefinder's boot time


# Extra Requirements 

- Requires a [rangefinder module](https://noptel.fi/rangefinderhome) from [Noptel Oy](https://noptel.fi/)


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
