### PR TITLE
wiegand_reader 1.4

### DIFF
--- a/applications/GPIO/wiegand_reader/README.md
+++ b/applications/GPIO/wiegand_reader/README.md
@@ -1,0 +1,3 @@
+## Status
+
+[![wiegand_reader](https://catalog.flipperzero.one/application/wiegand_reader/widget)](https://catalog.flipperzero.one/application/wiegand_reader/page)

--- a/applications/GPIO/wiegand_reader/manifest.yml
+++ b/applications/GPIO/wiegand_reader/manifest.yml
@@ -1,0 +1,19 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/jamisonderek/flipper-zero-tutorials
+    commit_sha: ef5dfb57fbb559fe760c15dcfc6c4b6abbd19b15
+    subdir: gpio/wiegand
+category: "GPIO"
+short_description: "Application for reading and sending Wiegand signals. Connect D0, D1, GND wires to Flipper Zero to read signals."
+id: "wiegand_reader"
+description: "@docs/README.md"
+changelog: "@docs/CHANGELOG.md"
+author: "Derek Jamison (@CodeAllNight)"
+version: "1.4"
+screenshots:
+  - "docs/image0.png"
+  - "docs/image1.png"
+  - "docs/image2.png"
+  - "docs/image3.png"
+  - "docs/image4.png"


### PR DESCRIPTION
# Application Submission

- This application allows you to read Wiegand signals from a keypad by connecting the D0, D1 and GND wires to the Flipper Zero.
- If supported by your Wiegand reader, you can add 4.7K inline resistors and then use the application to pull the lines to ground, allowing you to resend Wiegand data.
- You can also add 2 MOSFETs to allow the Flipper Zero to tap into a Wiegand reader that requires the lines have a lower impedance.

# Extra Requirements 

- You need a Wiegand reader with green (D0)/white(D1) and black (GND) wires to connect to the device. (Or you could simulate it with a second Flipper Zero running the app and loading the example file from the projects GitHub example/C1.wgn file.)
- To test sending you need a few 4.7K resistors, a Wiegand reader and a Wiegand control panel. You can also simulate it using 3 Flipper Zeros running the app.

# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
