### PR TITLE
Bump Metroflip to V0.9

### DIFF
--- a/applications/NFC/metroflip/manifest.yml
+++ b/applications/NFC/metroflip/manifest.yml
@@ -23,8 +23,8 @@ screenshots:
 short_description: 'An implementation of Metrodroid on the Flipper Zero'
 sourcecode:
   location:
-    commit_sha: ac81567e6f87290435762c6d0d47b9dfc26058e5
+    commit_sha: 8472fbce191f0c5fab3bbb85423a8416d2107128
     origin: https://github.com/luu176/Metroflip
     subdir:
   type: git
-version: 0.8
+version: 0.9


### PR DESCRIPTION
# Application Submission

- Fix unsupported card crash
- RENFE Suma 10 support ADDED
- GEG Connect AID added to DESfire list.
- Top Up log parsing and animations.
- 16 new rail lines, including JR lines like Chuo, Negishi, Joban, and Yamanote; and all of Tokyu's operating lines.
- Added support for parsing area codes for future expansion on non-Tokyo areas.
- Added saving function for Suica/Japan Rail IC readings.
- Various bug fixes and safer memory manegements improvements.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
