### PR TITLE
Add Embraco Starter

### DIFF
--- a/applications/Tools/embraco_starter/manifest.yml
+++ b/applications/Tools/embraco_starter/manifest.yml
@@ -5,27 +5,35 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/graycoderep/Embraco-Starter.git
-  commit_sha: 7be623d2edf8133ae8754f7159972703163e5252
+    commit_sha: 7be623d2edf8133ae8754f7159972703163e5252
   subdir: .
 
 app:
+  # Explicit values to avoid FAM fallbacks
   name: Embraco Starter
   version: "1.0.0"
-  fap_author: "Adam Gray (Expert Hub)"
-  fap_weburl: https://experthub.app/
+  author: "Adam Gray (Expert Hub)"
   license: Apache-2.0
+  homepage: https://experthub.app/
+
   entry_point: embraco_starter
   requires:
     - gui
   stack_size: 2048
+
+  # FAP metadata (icon must be 10x10, 1‑bit PNG, no alpha)
   fap_icon: icon_embraco.png
+
+  # Catalog descriptions
   short_description: "Three-speed hardware PWM starter for Embraco compressors (safe Hi-Z startup & exit)."
   long_description: >
     Embraco Starter safely tests Embraco inverter compressors using hardware PWM on PA7.
     The app opens with Help (pin set to Hi-Z), offers Power off, Low (55 Hz), Mid (100 Hz), Max (160 Hz)
     modes at 50% duty, and returns PA7 to Hi-Z on exit.
+
   categories:
     - Tools
+
   screenshots:
     - screenshot_1.png
     - screenshot_2.png


### PR DESCRIPTION
# Application Submission

- Embraco Starter — a utility for safe startup and testing of Embraco inverter compressors on Flipper Zero.
- Hardware PWM on PA7 (50% duty).
- Modes: Power Off, Low (55 Hz), Mid (100 Hz), Max (160 Hz).
- Safety first: app opens with Help and PA7 in Hi‑Z; PA7 returns to Hi‑Z on exit.
- Simple UI with a selector and a dedicated Help screen (wiring + notes). ]


# Extra Requirements 

- 2 wires to connect inverter


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
