### PR TITLE
Add embraco starter

### DIFF
--- a/applications/Tools/embraco_starter/manifest.yml
+++ b/applications/Tools/embraco_starter/manifest.yml
@@ -5,7 +5,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/graycoderep/Embraco-Starter.git
-    commit_sha: 941a5d4fae8bd48a1c2f89b668dd037c92e6a2b0
+    commit_sha: 36d093f85b1c253725add55874063e48f4f37203
   subdir: src
 
 app:
@@ -37,3 +37,7 @@ app:
 screenshots:
   - media/screenshot1.png
   - media/screenshot2.png
+  - media/screenshot3.png
+  - media/screenshot4.png
+  - media/screenshot5.png
+  - media/screenshot6.png


### PR DESCRIPTION
# Application Submission

- Embraco Starter — a utility for safe startup and testing of Embraco inverter compressors on Flipper Zero.
- Hardware PWM on PA7 (50% duty).
- Modes: Power Off, Low (55 Hz), Mid (100 Hz), Max (160 Hz).
- Safety first: app opens with Help and PA7 in Hi‑Z; PA7 returns to Hi‑Z on exit.
- Simple UI with a selector and a dedicated Help screen (wiring + notes). ]


# Extra Requirements 

- 2 wires to connect inverter


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [x] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
