### PR TITLE
bump to 1.1.1

### DIFF
--- a/applications/GPIO/401_digilab/manifest.yml
+++ b/applications/GPIO/401_digilab/manifest.yml
@@ -6,7 +6,7 @@ sourcecode:
     ## Specify the git URL of your repository
     origin: https://github.com/lab-401/fzDigiLab
     ## Put the full commit SHA of the commit with the app's code you want to submit
-    commit_sha: 3780cc1e63d07415976a949886fc5f3e92f0071a
+    commit_sha: 0b48d832849d74b4e75cfcfca0ddf13a877b5b95
     ## (Optional) If your app is located in a subdirectory of the repository, specify it here
     subdir: ./401DigiLabApp
 ## If application.fam contains 'fap_description', it will be used as a short description


### PR DESCRIPTION
# Application Submission

- Companion app for lab401's DigiLab hardware module, bump to v1.1.1


# Extra Requirements 

- require  lab401's DigiLab hardware module

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
