### PR TITLE
flipper_share: bump to v1.1

### DIFF
--- a/applications/Bluetooth/hid_ble_slack/manifest.yml
+++ b/applications/Bluetooth/hid_ble_slack/manifest.yml
@@ -1,0 +1,16 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/lomalkin/flipper-apps.git
+    commit_sha: ad9916e9e4b9d239b16a650500ad05b46108ff4f
+    subdir: hid_app
+id: hid_ble_slack
+short_description: BLE HID app fork with Slack support
+description: "@README.md"
+changelog: "@./docs/changelog.md"
+screenshots:
+  - "./.catalog/screenshots/1.png"
+  - "./.catalog/screenshots/2.png"
+  - "./.catalog/screenshots/3.png"
+  - "./.catalog/screenshots/4.png"
+  - "./.catalog/screenshots/5.png"


### PR DESCRIPTION
# Application Submission

- Flipper Share is a wireless-enabled file sharing application for Flipper Zero.
- Bump version to v1.1 (Improved GUI)


# Extra Requirements 

- Two flippers needed to check the app


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
