### PR TITLE
 VEML7700 Lux Meter

### DIFF
--- a/applications/GPIO/LuxMeterVEML7700/manifest.yml
+++ b/applications/GPIO/LuxMeterVEML7700/manifest.yml
@@ -1,4 +1,4 @@
-id: "veml7700luxmeter"
+id: "LuxMeterVEML7700"
 name: "VEML7700 Lux Meter"
 author: "@Dr.Mosfet"
 category: "GPIO"

--- a/applications/GPIO/LuxMeterVEML7700/manifest.yml
+++ b/applications/GPIO/LuxMeterVEML7700/manifest.yml
@@ -1,15 +1,21 @@
-id: LuxMeterVEML7700
+id: "veml7700luxmeter"
+name: "VEML7700 Lux Meter"
+author: "@Dr.Mosfet"
+category: "GPIO"
+version: "1.0"
+targets:
+  - "all"
 sourcecode:
   type: git
   location:
     origin: https://github.com/kamylwnb/Flipper-zero-app-VEML7700
     commit_sha: 7ab6ac3c6711d844739627c1a8dd0615757bfa18
     subdir: .
-short_description: Lux meter app using VEML7700 sensor for Flipper Zero
+short_description: "Lux meter app using VEML7700 sensor for Flipper Zero"
 description: |
-  The VEML7700 Lux Meter app measures ambient light in lux using the VEML7700 sensor via I2C and displays the value on the Flipper Zero screen.   
+  The VEML7700 Lux Meter app measures ambient light in lux using the VEML7700 sensor via I2C and displays the value on the Flipper Zero screen.
   Requires a VEML7700 sensor connected via I2C to the Flipper Zero GPIO pins.
-changelog: "@CHANGELOG.md"
+changelog: "docs/CHANGELOG.md"
 screenshots:
   - screenshots/1.png
   - screenshots/2.png

--- a/applications/GPIO/LuxMeterVEML7700/manifest.yml
+++ b/applications/GPIO/LuxMeterVEML7700/manifest.yml
@@ -9,7 +9,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/kamylwnb/Flipper-zero-app-VEML7700
-    commit_sha: 7ab6ac3c6711d844739627c1a8dd0615757bfa18
+    commit_sha: b2f61f1613d56ddabe7eb9bef8386be98be1c49a
     subdir: .
 short_description: "Lux meter app using VEML7700 sensor for Flipper Zero"
 description: |

--- a/applications/GPIO/LuxMeterVEML7700/manifest.yml
+++ b/applications/GPIO/LuxMeterVEML7700/manifest.yml
@@ -1,21 +1,14 @@
 sourcecode:
   type: git
   location:
-    # URL of the Git repository containing the app's code
     origin: https://github.com/kamylwnb/Flipper-zero-app-VEML7700
-    # SHA of the commit with the app's code for submission
     commit_sha: 7ab6ac3c6711d844739627c1a8dd0615757bfa18
-    # Subdirectory in the repository where the app's code is located, or . for the root
     subdir: .
-# Short description of the app
 short_description: Lux meter app using VEML7700 sensor for Flipper Zero
-# Full description and changelog in simple Markdown, can reference a file in the repo with @
 description: |
   The VEML7700 Lux Meter app measures ambient light in lux using the VEML7700 sensor via I2C and displays the value on the Flipper Zero screen.   
   Requires a VEML7700 sensor connected via I2C to the Flipper Zero GPIO pins.
-# File with the app's changelog, e.g., CHANGELOG.md
 changelog: "@CHANGELOG.md"
-# List of unedited screenshots from qFlipper
 screenshots:
   - screenshots/1.png
   - screenshots/2.png

--- a/applications/GPIO/LuxMeterVEML7700/manifest.yml
+++ b/applications/GPIO/LuxMeterVEML7700/manifest.yml
@@ -9,7 +9,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/kamylwnb/Flipper-zero-app-VEML7700
-    commit_sha: b2f61f1613d56ddabe7eb9bef8386be98be1c49a
+    commit_sha: 81b0d2b63cbd75cafbba8cd94807d4a3606007ba
     subdir: .
 short_description: "Lux meter app using VEML7700 sensor for Flipper Zero"
 description: |

--- a/applications/GPIO/LuxMeterVEML7700/manifest.yml
+++ b/applications/GPIO/LuxMeterVEML7700/manifest.yml
@@ -1,3 +1,4 @@
+id: LuxMeterVEML7700
 sourcecode:
   type: git
   location:

--- a/applications/GPIO/LuxMeterVEML7700/manifest.yml
+++ b/applications/GPIO/LuxMeterVEML7700/manifest.yml
@@ -1,0 +1,22 @@
+sourcecode:
+  type: git
+  location:
+    # URL of the Git repository containing the app's code
+    origin: https://github.com/kamylwnb/Flipper-zero-app-VEML7700
+    # SHA of the commit with the app's code for submission
+    commit_sha: 7ab6ac3c6711d844739627c1a8dd0615757bfa18
+    # Subdirectory in the repository where the app's code is located, or . for the root
+    subdir: .
+# Short description of the app
+short_description: Lux meter app using VEML7700 sensor for Flipper Zero
+# Full description and changelog in simple Markdown, can reference a file in the repo with @
+description: |
+  The VEML7700 Lux Meter app measures ambient light in lux using the VEML7700 sensor via I2C and displays the value on the Flipper Zero screen.   
+  Requires a VEML7700 sensor connected via I2C to the Flipper Zero GPIO pins.
+# File with the app's changelog, e.g., CHANGELOG.md
+changelog: "@CHANGELOG.md"
+# List of unedited screenshots from qFlipper
+screenshots:
+  - screenshots/1.png
+  - screenshots/2.png
+  - screenshots/3.png

--- a/applications/GPIO/LuxMeterVEML7700/manifest.yml
+++ b/applications/GPIO/LuxMeterVEML7700/manifest.yml
@@ -1,4 +1,4 @@
-id: "LuxMeterVEML7700"
+id: "veml7700luxmeter"
 name: "VEML7700 Lux Meter"
 author: "@Dr.Mosfet"
 category: "GPIO"


### PR DESCRIPTION
Application Submission

The VEML7700 Lux Meter application measures ambient light intensity in lux using the VEML7700 sensor, communicating via the I2C bus through GPIO pins. The application displays real-time lux readings on the Flipper Zero screen.

# Extra Requirements 

This application requires an external VEML7700 light sensor connected to the GPIO pins. Communication is handled via the I2C bus.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](https://github.com/flipperdevices/flipper-application-catalog/blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x]  I own the code I'm submitting or have code owner's permission to submit it
- [ ] I [have validated](https://github.com/flipperdevices/flipper-application-catalog/blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with python3 tools/bundle.py --nolint applications/GPIO/veml7700luxmeter/manifest.yml bundle.zip

# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [x] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
