### PR TITLE
Add TonUINO Writer v2.0.0

### DIFF
--- a/applications/NFC/tonuino_writer/manifest.yml
+++ b/applications/NFC/tonuino_writer/manifest.yml
@@ -1,29 +1,11 @@
-# Flipper Application Catalog Manifest
-# https://github.com/flipperdevices/flipper-application-catalog
-
-# IMPORTANT: Update these values after creating your GitHub repository
-id: tonuino_writer
-category: NFC
-
-# GitHub repository information
-source_code: https://github.com/Bastelsaal/tonuino-flipper-zero
-
-# Commit SHA reference - use the commit hash from your repository
-commit: 24c99d3
-
-# Application metadata
-name: TonUINO Writer
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Bastelsaal/tonuino-flipper-zero.git
+    commit_sha: 3c14aaad3f1e719bf456aa1ec749109cf6214fb9
 short_description: NFC card writer for TonUINO audio boxes
-description: |
-  Create and manage NFC cards for TonUINO DIY music player systems.
-  Write, read, and preview TonUINO MIFARE Classic cards with all 11 play modes.
-  Features cancelable operations, rapid write mode, and menu position memory.
-
-# Icon and screenshots
-# Icon should be 10x10px PNG in your repository
-icon: icon.png
-
-# Screenshots showing key features
+description: "@README.md"
+changelog: "@changelog.md"
 screenshots:
   - screenshots/01_main_menu.png
   - screenshots/02_set_folder.png
@@ -31,20 +13,3 @@ screenshots:
   - screenshots/05_view_card.png
   - screenshots/06_write_waiting.png
   - screenshots/09_rapid_write.png
-
-# Application version
-version: 2.0.0
-
-# Author information
-author: Thomas Kekeisen-Schanz
-author_github: blaues0cke
-
-# Optional: Project homepage
-# webpage: https://www.tonuino.de
-
-# Changelog reference
-changelog: changelog.md
-
-# Build configuration
-# The catalog will build your app using uFBT
-# Ensure your application.fam is correctly configured

--- a/applications/NFC/tonuino_writer/manifest.yml
+++ b/applications/NFC/tonuino_writer/manifest.yml
@@ -1,0 +1,50 @@
+# Flipper Application Catalog Manifest
+# https://github.com/flipperdevices/flipper-application-catalog
+
+# IMPORTANT: Update these values after creating your GitHub repository
+id: tonuino_writer
+category: NFC
+
+# GitHub repository information
+source_code: https://github.com/Bastelsaal/tonuino-flipper-zero
+
+# Commit SHA reference - use the commit hash from your repository
+commit: 24c99d3
+
+# Application metadata
+name: TonUINO Writer
+short_description: NFC card writer for TonUINO audio boxes
+description: |
+  Create and manage NFC cards for TonUINO DIY music player systems.
+  Write, read, and preview TonUINO MIFARE Classic cards with all 11 play modes.
+  Features cancelable operations, rapid write mode, and menu position memory.
+
+# Icon and screenshots
+# Icon should be 10x10px PNG in your repository
+icon: icon.png
+
+# Screenshots showing key features
+screenshots:
+  - screenshots/01_main_menu.png
+  - screenshots/02_set_folder.png
+  - screenshots/03_set_mode.png
+  - screenshots/05_view_card.png
+  - screenshots/06_write_waiting.png
+  - screenshots/09_rapid_write.png
+
+# Application version
+version: 2.0.0
+
+# Author information
+author: Thomas Kekeisen-Schanz
+author_github: blaues0cke
+
+# Optional: Project homepage
+# webpage: https://www.tonuino.de
+
+# Changelog reference
+changelog: changelog.md
+
+# Build configuration
+# The catalog will build your app using uFBT
+# Ensure your application.fam is correctly configured

--- a/applications/NFC/tonuino_writer/manifest.yml
+++ b/applications/NFC/tonuino_writer/manifest.yml
@@ -2,9 +2,9 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Bastelsaal/tonuino-flipper-zero.git
-    commit_sha: 1af30fd0e462c42b3993909e924ea0be44710e98
+    commit_sha: 11de379b67b37d24bb1812dd8c361b8f2b5c9999
 short_description: NFC card writer for TonUINO audio boxes
-description: "@README.md"
+description: "@docs/catalog_description.md"
 changelog: "@changelog.md"
 screenshots:
   - screenshots/01_main_menu.png

--- a/applications/NFC/tonuino_writer/manifest.yml
+++ b/applications/NFC/tonuino_writer/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Bastelsaal/tonuino-flipper-zero.git
-    commit_sha: 3c14aaad3f1e719bf456aa1ec749109cf6214fb9
+    commit_sha: 1af30fd0e462c42b3993909e924ea0be44710e98
 short_description: NFC card writer for TonUINO audio boxes
 description: "@README.md"
 changelog: "@changelog.md"


### PR DESCRIPTION
# Application Submission

  TonUINO Writer is an NFC card writer application for TonUINO audio boxes - a DIY music player system for children that uses NFC cards to trigger playback.

  ## Features
  - **Write TonUINO Cards**: Configure NFC cards with folder, mode, and special settings
  - **Read TonUINO Cards**: Read and display existing card configurations
  - **Rapid Write Mode**: Quickly write multiple cards with adjustable settings
  - **Cancelable Operations**: Cancel read/write operations at any time with dedicated Cancel button
  - **Card Preview**: View card configuration before writing
  - **Menu Position Memory**: Returns to your last selected menu item
  - **All 11 Play Modes**: Complete TonUINO mode support

  ## Technical Details
  - Non-blocking NFC operations using FuriThread
  - SceneManager architecture for stable navigation
  - Supports MIFARE Classic 1K cards
  - Writes to block 4 with TonUINO-compatible format

  # Extra Requirements

  - **Hardware**: MIFARE Classic 1K NFC cards (standard TonUINO cards)
  - **Software**: No extra software requirements - runs on official and Unleashed firmware

  # Author Checklist (Fill this out)

  - [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
  - [x] I own the code I'm submitting or have code owner's permission to submit it
  - [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/NFC/tonuino_writer/manifest.yml bundle.zip`

  ---

  **Repository**: https://github.com/Bastelsaal/tonuino-flipper-zero
  **Author**: Thomas Kekeisen-Schanz (@blaues0cke)
  **Version**: 2.0.0
  **Category**: NFC
  **License**: MIT
  **Commit**: 2328b9d983c9c5a909df4b7354bf327ec85a11fe