### PR TITLE
Add CaiXianlin Remote App

### DIFF
--- a/applications/Sub-GHz/caixianlin_remote/manifest.yml
+++ b/applications/Sub-GHz/caixianlin_remote/manifest.yml
@@ -1,0 +1,14 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/anty-ce/flipper_zero_caixianlin_remote.git
+    commit_sha: e1f11be6b60dc4eb1f8ca69bb78277e6f03f6ccc
+short_description: Remote control for CaiXianlin shock collar via Sub-GHz radio
+description: "@SIMPLE_README.md"
+changelog: "@changelog.md"
+screenshots:
+  - screenshots/0-home-vibrate.png
+  - screenshots/1-home-beep.png
+  - screenshots/2-setup.png
+  - screenshots/3-listen-waiting.png
+  - screenshots/4-setup-edit-station-id.png


### PR DESCRIPTION
# Application Submission

A Flipper Zero application for controlling the CaiXianlin shock collar (the main one used by both [PiShock](https://pishock.com/) and [OpenShock](https://openshock.org/)).

Let me know if this kind of app is acceptable for the submission! I'm open to creating a stripped-down version for the catalog if this oversteps the app store's guidelines or similar. ^^


# Extra Requirements

None


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
