### PR TITLE
Add co2_detector_mh_z19 app

### DIFF
--- a/applications/GPIO/co2_detector_mh_z19/manifest.yml
+++ b/applications/GPIO/co2_detector_mh_z19/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/razerhome/flipper-zero-co2-mh-z19.git
-    commit_sha: f0933f0739715128b5ba95787ec6cab1570b175e
+    commit_sha: f73f2f25dec88463525af0fc42bc4944a60c6827
 description: "@README.md"
 changelog: "@CHANGELOG.md"
 screenshots:

--- a/applications/GPIO/co2_detector_mh_z19/manifest.yml
+++ b/applications/GPIO/co2_detector_mh_z19/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/razerhome/flipper-zero-co2-mh-z19.git
-    commit_sha: f9b62f6
+    commit_sha: 43d8626
 description: "@README.md"
 changelog: "@CHANGELOG.md"
 screenshots:

--- a/applications/GPIO/co2_detector_mh_z19/manifest.yml
+++ b/applications/GPIO/co2_detector_mh_z19/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/razerhome/flipper-zero-co2-mh-z19.git
-    commit_sha: 0c19f7f
+    commit_sha: a612aa8
 description: "@README.md"
 changelog: "@CHANGELOG.md"
 screenshots:

--- a/applications/GPIO/co2_detector_mh_z19/manifest.yml
+++ b/applications/GPIO/co2_detector_mh_z19/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/razerhome/flipper-zero-co2-mh-z19.git
-    commit_sha: f73f2f25dec88463525af0fc42bc4944a60c6827
+    commit_sha: f9b62f6
 description: "@README.md"
 changelog: "@CHANGELOG.md"
 screenshots:

--- a/applications/GPIO/co2_detector_mh_z19/manifest.yml
+++ b/applications/GPIO/co2_detector_mh_z19/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/razerhome/flipper-zero-co2-mh-z19.git
-    commit_sha: 43d8626
+    commit_sha: 0c19f7f
 description: "@README.md"
 changelog: "@CHANGELOG.md"
 screenshots:

--- a/applications/GPIO/co2_detector_mh_z19/manifest.yml
+++ b/applications/GPIO/co2_detector_mh_z19/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/razerhome/flipper-zero-co2-mh-z19.git
-    commit_sha: a612aa8
+    commit_sha: a612aa84a1e3cb584931a4155c51d8d82e645c65
 description: "@README.md"
 changelog: "@CHANGELOG.md"
 screenshots:

--- a/applications/GPIO/co2_detector_mh_z19/manifest.yml
+++ b/applications/GPIO/co2_detector_mh_z19/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/razerhome/flipper-zero-co2-mh-z19.git
-    commit_sha: a612aa84a1e3cb584931a4155c51d8d82e645c65
+    commit_sha: 946a34a16bc527acfa9b63c76895d81065fe4f6f
 description: "@README.md"
 changelog: "@CHANGELOG.md"
 screenshots:

--- a/applications/GPIO/co2_detector_mh_z19/manifest.yml
+++ b/applications/GPIO/co2_detector_mh_z19/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/razerhome/flipper-zero-co2-mh-z19.git
-    commit_sha: 946a34a16bc527acfa9b63c76895d81065fe4f6f
+    commit_sha: 532deebaeed5bd11972ac01a693f1500df37f5be
 description: "@README.md"
 changelog: "@CHANGELOG.md"
 screenshots:

--- a/applications/GPIO/co2_detector_mh_z19/manifest.yml
+++ b/applications/GPIO/co2_detector_mh_z19/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/razerhome/flipper-zero-co2-mh-z19.git
-    commit_sha: 532deebaeed5bd11972ac01a693f1500df37f5be
+    commit_sha: 00fd95d7c37099703537e9878629519bc64eba11
 description: "@README.md"
 changelog: "@CHANGELOG.md"
 screenshots:

--- a/applications/GPIO/mh_z19/manifest.yml
+++ b/applications/GPIO/mh_z19/manifest.yml
@@ -1,0 +1,15 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/meshchaninov/flipper-zero-mh-z19
+    commit_sha: 6120a542290469ab81b1691fad5cbcb709ff0172
+short_description: |
+  Measuring carbon dioxide (CO2) with mh-z19 
+description: |
+  Application for measuring carbon dioxide (CO2) with mh-z19 sensor and Flipper zero
+changelog: "@CHANGELOG.md"
+author: "@meshchaninov"
+screenshots:
+  - assets/Ok.png
+  - assets/Very.png
+  

--- a/applications/GPIO/mh_z19/manifest.yml
+++ b/applications/GPIO/mh_z19/manifest.yml
@@ -1,15 +1,11 @@
 sourcecode:
   type: git
   location:
-    origin: https://github.com/meshchaninov/flipper-zero-mh-z19
-    commit_sha: 6120a542290469ab81b1691fad5cbcb709ff0172
-short_description: |
-  Measuring carbon dioxide (CO2) with mh-z19 
-description: |
-  Application for measuring carbon dioxide (CO2) with mh-z19 sensor and Flipper zero
+    origin: https://github.com/razerhome/flipper-zero-co2-mh-z19.git
+    commit_sha: f0933f0739715128b5ba95787ec6cab1570b175e
+description: "@README.md"
 changelog: "@CHANGELOG.md"
-author: "@meshchaninov"
 screenshots:
-  - assets/Ok.png
-  - assets/Very.png
-  
+  - assets/screen_ok.png
+  - assets/screen_bad.png
+  - assets/screen_graph.png


### PR DESCRIPTION
## New application: CO2 detector MH-Z19

**App ID:** `co2_detector_mh_z19`
**Category:** GPIO
**Source:** https://github.com/razerhome/flipper-zero-co2-mh-z19

### Description

CO2 concentration detector for Flipper Zero using MH-Z19 sensor via PWM (3-wire connection: 5V, GND, PWM).

Fork of [meshchaninov/flipper-zero-mh-z19](https://github.com/meshchaninov/flipper-zero-mh-z19) with signal filtering, calibration offset, history graph, and multi-screen navigation.

### Features

- Stable readings with 4-stage filter (validation, median, EMA, hysteresis)
- Fast 1 ms GPIO polling for accurate PWM measurement
- Calibration offset (±500 ppm) to match a reference sensor
- CO2 history graph with auto-scaling (10 min to 11+ hours)
- Battery percentage on graph screen
- Debug screen with raw PWM data
- LED + vibro alerts at 800/1000 ppm thresholds

### Checklist

- [x] App builds with uFBT (latest release SDK)
- [x] Open source license (MIT)
- [x] App icon 10x10px 1-bit PNG
- [x] Screenshots from qFlipper
- [x] README.md with usage instructions
- [x] CHANGELOG.md