### PR TITLE
Add Hold 'em

### DIFF
--- a/applications/Games/holdem/manifest.yml
+++ b/applications/Games/holdem/manifest.yml
@@ -4,7 +4,6 @@ sourcecode:
     origin: https://github.com/code-phreak/flipper-holdem.git
     commit_sha: f2e41e71f7633ed76622ea57088b0c928b095020
 
-short_description: Texas Hold'em for Flipper Zero
 description: "@.catalog/README.md"
 changelog: "@.catalog/CHANGELOG.md"
 author: "code-phreak"

--- a/applications/Games/holdem/manifest.yml
+++ b/applications/Games/holdem/manifest.yml
@@ -3,8 +3,8 @@ sourcecode:
   location:
     origin: https://github.com/code-phreak/flipper-holdem.git
     commit_sha: f2e41e71f7633ed76622ea57088b0c928b095020
-    subdir: .
 
+short_description: Texas Hold'em for Flipper Zero
 description: "@.catalog/README.md"
 changelog: "@.catalog/CHANGELOG.md"
 author: "code-phreak"
@@ -22,9 +22,3 @@ screenshots:
   - ".catalog/screenshots/10-showdown.png"
   - ".catalog/screenshots/11-results.png"
   - ".catalog/screenshots/12-you-won.png"
-
-current_version:
-  type: externalApp
-  value: "1.1"
-  fap_sha256: "10B9E1B0405846B3624D09DB36DF964B359B534552A5E3AD66137142846E6F5A"
-  catalog_api: 87.1

--- a/applications/Games/holdem/manifest.yml
+++ b/applications/Games/holdem/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/code-phreak/flipper-holdem.git
-    commit_sha: f77f68867977fdbc4ac236cf0ade7744c62a3335
+    commit_sha: a81f65a011ef727a973bc60a698878a1949cee73
     subdir: .
 
 description: "@.catalog/README.md"
@@ -15,12 +15,16 @@ screenshots:
   - ".catalog/screenshots/03-big-win.png"
   - ".catalog/screenshots/04-menu-1.png"
   - ".catalog/screenshots/05-menu-2.png"
-  - ".catalog/screenshots/06-hand-showdown.png"
-  - ".catalog/screenshots/07-hand-result.png"
-  - ".catalog/screenshots/08-you-won.png"
+  - ".catalog/screenshots/06-edit-blinds-1.png"
+  - ".catalog/screenshots/07-edit-blinds-2.png"
+  - ".catalog/screenshots/08-edit-bots.png"
+  - ".catalog/screenshots/09-hand-ranks.png"
+  - ".catalog/screenshots/10-showdown.png"
+  - ".catalog/screenshots/11-results.png"
+  - ".catalog/screenshots/12-you-won.png"
 
 current_version:
   type: externalApp
-  value: "1.0"
-  fap_sha256: "5B5D0107893ABD3781C323B954CB1AF7949BC6BB38659BA24F6E2441A83A763B"
+  value: "1.1"
+  fap_sha256: "329189FA2DC7FB027C431B469F12A0BF3855F47D5AACD08B2318749AF8B2228E"
   catalog_api: 87.1

--- a/applications/Games/holdem/manifest.yml
+++ b/applications/Games/holdem/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/code-phreak/flipper-holdem.git
-    commit_sha: a81f65a011ef727a973bc60a698878a1949cee73
+    commit_sha: f2e41e71f7633ed76622ea57088b0c928b095020
     subdir: .
 
 description: "@.catalog/README.md"
@@ -26,5 +26,5 @@ screenshots:
 current_version:
   type: externalApp
   value: "1.1"
-  fap_sha256: "329189FA2DC7FB027C431B469F12A0BF3855F47D5AACD08B2318749AF8B2228E"
+  fap_sha256: "10B9E1B0405846B3624D09DB36DF964B359B534552A5E3AD66137142846E6F5A"
   catalog_api: 87.1

--- a/applications/Games/holdem/manifest.yml
+++ b/applications/Games/holdem/manifest.yml
@@ -1,0 +1,26 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/code-phreak/flipper-holdem.git
+    commit_sha: f77f68867977fdbc4ac236cf0ade7744c62a3335
+    subdir: .
+
+description: "@.catalog/README.md"
+changelog: "@.catalog/CHANGELOG.md"
+author: "code-phreak"
+
+screenshots:
+  - ".catalog/screenshots/01-first-screen.png"
+  - ".catalog/screenshots/02-main-table.png"
+  - ".catalog/screenshots/03-big-win.png"
+  - ".catalog/screenshots/04-menu-1.png"
+  - ".catalog/screenshots/05-menu-2.png"
+  - ".catalog/screenshots/06-hand-showdown.png"
+  - ".catalog/screenshots/07-hand-result.png"
+  - ".catalog/screenshots/08-you-won.png"
+
+current_version:
+  type: externalApp
+  value: "1.0"
+  fap_sha256: "5B5D0107893ABD3781C323B954CB1AF7949BC6BB38659BA24F6E2441A83A763B"
+  catalog_api: 87.1


### PR DESCRIPTION
# Application Submission

- Hold 'em is a native single-player Texas Hold'em game built specifically for Flipper Zero.
- The current release includes full hand flow from preflop through showdown, support for 1 to 3 CPU opponents, side-pot-aware payout handling, and single-slot save/load with full game-state persistence.
- Players can adjust bot count and blinds from the in-game menus, use on-device controls help, and restart cleanly without leaving the app.
- The UI is tuned for the Flipper screen with compact card rendering, bitmap suit icons, readable betting flow, and persistent win/loss end screens.
- This submission is for the initial public `v1.0` release.

# Extra Requirements

- No extra hardware is required beyond a Flipper Zero compatible with external apps.
- No extra software is required for end users beyond installing the `.fap` on the device.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
