### PR TITLE
Add Gatekeeper app

### DIFF
--- a/applications/Tools/Gatekeeper/README.md
+++ b/applications/Tools/Gatekeeper/README.md
@@ -1,0 +1,22 @@
+# Gatekeeper
+
+## Gatekeeper is a password manager for Flipper Zero that uses BadUSB (HID emulation).
+### It allows you to store frequently used credentials and automatically enter them on any computer or terminal with a single click.
+
+Features:
+- **BadUSB Integration:** Gatekeeper can emulate a USB keyboard and automatically enter saved strings (passwords, tokens, commands).
+- **Master Combo Protection:** Each time you launch the device, you are required to enter a secret combination of the 4-way D-pad (Up/Down/Left/Right).
+- **Password Storage:** You can save up to 30 entries.
+
+Password storage contains:
+- Label — the entry name
+- Payload — the string to be entered via BadUSB
+- Icon — a visual icon for easy navigation
+
+
+> note: While Gatekeeper uses Master Combo to protect access, Flipper Zero does not have a hardware Secure Element for application encryption.
+Therefore, we recommend:
+ not storing root passwords,
+ not storing crypto wallet seed phrases,
+ not storing financial recovery keys.
+ The app is designed for convenient and quick entry of frequently used data.

--- a/applications/Tools/Gatekeeper/manifest.yml
+++ b/applications/Tools/Gatekeeper/manifest.yml
@@ -1,0 +1,12 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/enexis1337/Gatekeeper
+    commit_sha: 777369352e9d9d3ce7f131117dddc15de53e18b2
+short_description: A secure password vault and BadUSB injector for Flipper Zero.
+description: "@catalogReadme.md"
+changelog: "@CHANGELOG.md"
+screenshots:
+  - gitImages/List.png
+  - gitImages/setCombo.png
+  - gitImages/iconsSelect

--- a/applications/Tools/Gatekeeper/manifest.yml
+++ b/applications/Tools/Gatekeeper/manifest.yml
@@ -2,11 +2,12 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/enexis1337/Gatekeeper
-    commit_sha: 44cf4a3626175055a9654db35b7385ea03afb3cd
+    commit_sha: 395d54ada18f062cb4221046a71db898519d99b6
 short_description: A secure password vault and BadUSB injector for Flipper Zero.
 description: "@catalogReadme.md"
 changelog: "@CHANGELOG.md"
 screenshots:
+  - gitImages/deployMenu.png
   - gitImages/List.png
   - gitImages/setCombo.png
-  - gitImages/iconsSelect
+  - gitImages/iconsSelect.png

--- a/applications/Tools/Gatekeeper/manifest.yml
+++ b/applications/Tools/Gatekeeper/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/enexis1337/Gatekeeper
-    commit_sha: 777369352e9d9d3ce7f131117dddc15de53e18b2
+    commit_sha: 44cf4a3626175055a9654db35b7385ea03afb3cd
 short_description: A secure password vault and BadUSB injector for Flipper Zero.
 description: "@catalogReadme.md"
 changelog: "@CHANGELOG.md"


### PR DESCRIPTION
# Application Submission

- Gatekeeper is a password manager for Flipper Zero that uses BadUSB (HID emulation) to automatically type stored credentials into a computer.

Features:
- Stores up to 30 credentials
- Master Combo protection (4 directional inputs required on launch)
- Custom labels and icons for entries
- Instant password injection via BadUSB


# Extra Requirements 

- No extra hardware required. Works on any Flipper Zero with BadUSB support.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
