### PR TITLE
Add Agentic Remote (claude_remote_usb)

### DIFF
--- a/applications/USB/claude_remote_usb/manifest.yml
+++ b/applications/USB/claude_remote_usb/manifest.yml
@@ -1,0 +1,14 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Wet-wr-Labs/claupper.git
+    commit_sha: b1a8363c4b11a8d17c5cc5bf009231d37573fc92
+id: claude_remote_usb
+short_description: One-handed remote for AI coding agents (Claude Code). D-pad control, macros, offline manual + quiz.
+description: "@catalog_description.md"
+changelog: "@changelog.md"
+screenshots:
+  - screenshots/ss_splash.png
+  - screenshots/ss_manual.png
+  - screenshots/ss_manual2.png
+  - screenshots/ss_settings.png


### PR DESCRIPTION
## Application

One-handed Flipper Zero remote for AI coding agents (Claude Code). 5-button D-pad control — approve, decline, skip, enter, voice dictation. Customizable macros from SD card (up to 24), complete offline Claude Code manual with quiz mode. USB HID, stock firmware compatible.

Built by [Kasen Sansonetti](https://github.com/w3t-wr3) & [Wetware Labs](https://WetwareOfficial.com).

## Extra Requirements

No extra hardware or software required. Standard USB HID — works with any computer (Mac/Win/Linux).

## Author Checklist

- [x] I have read and followed the [contribution guidelines](https://github.com/flipperdevices/flipper-application-catalog/blob/main/documentation/Contributing.md)
- [x] I am the owner of the code or have permission to submit it
- [x] I have validated the manifest: `python3 tools/bundle.py --nolint applications/USB/claude_remote_usb/manifest.yml bundle.zip` — passes successfully