### PR TITLE
feat: :rocket: Add InfraFi app

### DIFF
--- a/applications/Infrared/infrafi/manifest.yml
+++ b/applications/Infrared/infrafi/manifest.yml
@@ -1,0 +1,16 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/amd989/InfraFi.git
+    commit_sha: 8fae727e1e237f0ca27dd88f8f8ef004191885e5
+short_description: Transmit WiFi credentials via IR to a Linux server
+description: "@README_CATALOG.md"
+changelog: "@changelog.md"
+screenshots:
+  - screenshots/ss1.png
+  - screenshots/ss2.png
+  - screenshots/ss3.png
+  - screenshots/ss4.png
+  - screenshots/ss5.png
+  - screenshots/ss6.png
+  - screenshots/ss7.png


### PR DESCRIPTION
Adding support for the InfraFi Infrared to WiFi app

# Application Submission

InfraFi transmits WiFi credentials from a Flipper Zero to a Linux server via infrared (RC-6 protocol at 36kHz). Built for headless servers (NAS boxes, Intel NUCs) where typing WiFi passwords is painful or impossible.

**Features:**
- Manual WiFi credential entry (SSID, password, security type, hidden network toggle)
- NFC WiFi tag scanning (NTAG213/215/216, standard NDEF WiFi Simple Configuration)
- Saved networks with auto-save to SD card (browse, resend, delete)
- Optional ACK feedback from the server — displays connection result and IP address on the Flipper screen
- CRC-8 payload integrity verification
- Multi-pass retransmission for reliability

This is the initial v1.0 submission.

# Extra Requirements

- A Linux server with a CIR (Consumer IR) receiver, such as the ITE8708 found in Intel NUCs
- The **infrafid** daemon must be installed on the server — available as .deb and .rpm packages from [GitHub Releases](https://github.com/amd989/InfraFi/releases)
- No extra hardware required on the Flipper side — uses the built-in IR blaster

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality