### PR TITLE
feat(catalog): add Sub Duplicate Finder application to catalog

### DIFF
--- a/applications/Sub-GHz/sub_dup_finder/manifest.yml
+++ b/applications/Sub-GHz/sub_dup_finder/manifest.yml
@@ -1,0 +1,19 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Endika/flipper-sub-dup.git
+    commit_sha: 379a6ce47bdb4e18d5cb21217aa30d3c61695d9d
+short_description: A Flipper Zero application to identify, manage, and safely clean up duplicate Sub-GHz (.sub) files.
+description: |
+  Sub Duplicate Finder is an optimized Flipper Zero application designed to reclaim storage space by managing duplicate Sub-GHz (.sub) files. Providing a safe and intuitive interface to group, review, and delete redundant signals directly from your device. It ensures stability and performance for your Sub-GHz storage management.
+author: Endika
+version: 1.2.0
+changelog: |
+  - Automated releases with release-please and FAP upload
+  - Refactored codebase into separate modules (SRP, DIP)
+  - Auto-versioned credits screen
+screenshots:
+  - assets/main_menu.png
+  - assets/groups.png
+  - assets/delete.png
+


### PR DESCRIPTION
# Application Submission

- Sub Duplicate Finder is an optimized Flipper Zero application designed to reclaim storage space by managing and cleaning up duplicate Sub-GHz (.sub) files. It features an efficient scanning algorithm using CRC32 checksums, dynamic file grouping, and an interactive UI for safe file management directly from the device.


# Extra Requirements 

- No extra hardware or software is required. This application is standalone and runs natively on the Flipper Zero.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
