### PR TITLE
Add Miele Scout RX2 IR remote app

### DIFF
--- a/applications/Infrared/miele_scout/manifest.yml
+++ b/applications/Infrared/miele_scout/manifest.yml
@@ -1,0 +1,5 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/kallevaravas/flipper-miele-scout.git
+    commit_sha: 80e3c1ee31a9e30f82141b994af722f2de8e8dd2

--- a/applications/Infrared/miele_scout/manifest.yml
+++ b/applications/Infrared/miele_scout/manifest.yml
@@ -2,4 +2,9 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/kallevaravas/flipper-miele-scout.git
-    commit_sha: 80e3c1ee31a9e30f82141b994af722f2de8e8dd2
+    commit_sha: 5cfcf8582e60f9ec742de61bc042524df02cf9da
+description: "@README.md"
+changelog: "@CHANGELOG.md"
+screenshots:
+  - screenshots/drive_mode.png
+  - screenshots/menu_buttons.png


### PR DESCRIPTION
Adds a Flipper Zero IR remote app for the Miele Scout RX2 robot vacuum.

Two modes:
- Drive mode: d-pad controls robot movement directly
- Menu mode: scrollable list for power, base, play/pause, mode, wifi, timer, clock, climb, mute

Built and tested with ufbt on official firmware.