### PR TITLE
Added uk_mbirth_sonicare

### DIFF
--- a/applications/NFC/uk_mbirth_sonicare/manifest.yml
+++ b/applications/NFC/uk_mbirth_sonicare/manifest.yml
@@ -1,0 +1,21 @@
+# Flipper Zero App Catalog manifest
+
+sourcecode:
+    type: git
+    location:
+        origin: https://git.mbirth.uk/flipper_zero/sonicare.git
+        commit_sha: 8933b64139f0653011201898d1d68cd3ffa6ce9d
+        #subdir: .
+short_description: Philips Sonicare brush head NFC reader
+description: |
+    This app reads the NFC chip in Sonicare brush heads
+    and shows the amount of time this head has been used
+    as well as the intended lifespan. It also generates
+    the NFC password from the UID and MFG code.
+changelog: "@CHANGELOG.md"
+screenshots:
+    # First one will be main image in app listing - make it count!
+    - screenshots/flp0.png
+    - screenshots/flp1.png
+    - screenshots/flp2.png
+    - screenshots/flp3.png


### PR DESCRIPTION
# Application Submission

- This app reads the NFC chip in Sonicare brush heads and shows the amount of time this head has been used as well as the intended lifespan. It also generates the NFC password from the UID and MFG code.


# Extra Requirements 

- none (apart from Sonicare brush heads to read using this app)


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
