### PR TITLE
Add claude_buddy to [USB]

### DIFF
--- a/applications/USB/claude_buddy/manifest.yml
+++ b/applications/USB/claude_buddy/manifest.yml
@@ -1,0 +1,18 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/jxw1102/flipper-claude-buddy.git
+    commit_sha: 79da7b4ece5c6a620c6d6729734374f0ea1caf24
+    subdir: flipper-app
+name: Claude Buddy
+id: claude_buddy
+short_description: "Physical companion for Claude Code - remote control with audio/haptic feedback"
+description: "@README.md"
+changelog: "@CHANGELOG.md"
+author: jxw1102
+screenshots:
+  - "./screenshots/1.png"
+  - "./screenshots/2.png"
+  - "./screenshots/3.png"
+  - "./screenshots/4.png"
+  - "./screenshots/5.png"

--- a/applications/USB/claude_buddy/manifest.yml
+++ b/applications/USB/claude_buddy/manifest.yml
@@ -2,11 +2,13 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/jxw1102/flipper-claude-buddy.git
-    commit_sha: 79da7b4ece5c6a620c6d6729734374f0ea1caf24
+    commit_sha: e77b1e73694a8aeab6c35eeff4f7af26db75d6dd
     subdir: flipper-app
 name: Claude Buddy
 id: claude_buddy
-short_description: "Physical companion for Claude Code - remote control with audio/haptic feedback"
+category: USB
+icon: "icons/claude_10x10.png"
+short_description: "Claude Code companion - physical remote control with audio feedback"
 description: "@README.md"
 changelog: "@CHANGELOG.md"
 author: jxw1102

--- a/applications/USB/claude_buddy/manifest.yml
+++ b/applications/USB/claude_buddy/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/jxw1102/flipper-claude-buddy.git
-    commit_sha: e77b1e73694a8aeab6c35eeff4f7af26db75d6dd
+    commit_sha: 93623b901f4b910aa8baf48415ad34d52e3e8af4
     subdir: flipper-app
 name: Claude Buddy
 id: claude_buddy

--- a/applications/USB/claude_buddy/manifest.yml
+++ b/applications/USB/claude_buddy/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/jxw1102/flipper-claude-buddy.git
-    commit_sha: 93623b901f4b910aa8baf48415ad34d52e3e8af4
+    commit_sha: 612382e0e4f6b080b8c8b4d6beec5240e594ea90
     subdir: flipper-app
 name: Claude Buddy
 id: claude_buddy


### PR DESCRIPTION
# Application Submission

- Claude Buddy turns a Flipper Zero into a physical companion for Claude Code.
- The app provides audio, vibration, LED, and on-screen feedback for Claude activity.
- It also lets the user control common Claude actions directly from the Flipper:
    - `Up`: start/stop voice dictation
    - `Left`: Escape
    - `Right`: open slash command menu
    - `OK`: Enter
- The app supports automatic transport selection: USB CDC when a cable is connected, otherwise Bluetooth LE serial.
- It includes permission prompts, status display, slash-command menu support, and session/activity notifications for Claude Code.


# Extra Requirements 

- Requires Claude Code running on a macOS.
- Requires the companion Claude Code plugin.
- Connection requires either USB or BLE.


# Author Checklist (Fill this out)

- [✅] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [✅] I own the code I'm submitting or have code owner's permission to submit it
- [✅] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/USB/claude_buddy/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
