### PR TITLE
Add NFC/mfp_reader 1.0

### DIFF
--- a/applications/NFC/mfp_reader/manifest.yml
+++ b/applications/NFC/mfp_reader/manifest.yml
@@ -1,0 +1,17 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Defensor7/flipperzero-mfp-reader.git
+    commit_sha: 27e7e830f83a0c3edb240913754498ad5e612aa5
+    subdir: app
+
+description: "@.catalog/README.md"
+changelog: "@.catalog/changelog.md"
+
+screenshots:
+  - .catalog/screenshots/1.png
+  - .catalog/screenshots/2.png
+  - .catalog/screenshots/3.png
+  - .catalog/screenshots/4.png
+  - .catalog/screenshots/5.png
+  - .catalog/screenshots/6.png

--- a/applications/NFC/mfp_reader/manifest.yml
+++ b/applications/NFC/mfp_reader/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Defensor7/flipperzero-mfp-reader.git
-    commit_sha: 27e7e830f83a0c3edb240913754498ad5e612aa5
+    commit_sha: 8d619e7f1cc46b1c3eed55eb7d8a6cdc0d1e6a57
     subdir: app
 
 description: "@.catalog/README.md"


### PR DESCRIPTION
MIFARE Plus SL3 reader, dumper and emulator. Identifies cards, recovers per-sector keys via dictionary attack, dumps blocks, and emulates the card with optional write-back.

Source: https://github.com/Defensor7/flipperzero-mfp-reader


# Application Submission

Initial release of **MFP Reader** v1.0 — a standalone Flipper Zero application for working with **MIFARE Plus SL3** smart cards.

The app implements the full MFP SL3 protocol over ISO 14443-4A using only stock firmware APIs (no firmware modifications, no extra patches). AES-128 is provided by a bundled tiny-AES-c library because mbedtls is not exported from the Flipper firmware.

**Features**

- **Card identification** — UID, SAK, ATQA, ATS parsing, manufacturer decoding via UID[0], BCC validation against block 0
- **Full sector dump** — recovers both KeyA and KeyB for every sector via dictionary attack with the bundled default key set plus any user `.dic` files dropped into `apps_data/mfp_reader/`
- **Live visual progress** — custom view with a per-sector activity grid that fills in real time as keys are found and blocks are read
- **Hex viewer** — scrollable monospace dump of every block (uses TextBoxFontHex)
- **Save / Load** — versioned `.mfp` text format with editable file names and a duplicate-name validator
- **MFP SL3 emulation** — full ISO 14443-4A listener implementing GetVersion, AuthFirst (0x70), AuthNonFirst (0x76), ReadEncrypted (0x31), WriteEncrypted (0xA1) with proper CMAC verification and session-key derivation per NXP AN10922
- **Two emulation modes** — *Writable* (the dump file is updated when the reader writes) or *Read-only* (writes are discarded)
- **Delete saved dumps** from inside the app via Actions → Delete

The dictionary attack uses an optimization that tracks the last successful KeyA and KeyB and tries them first on each new sector — typical cards reuse the same key set, so most sectors auth in a single attempt instead of a full dictionary pass.

**Tested on**

- Flipper Zero with stock firmware **API 87.1** (Release 1.4.3)
- Real **MIFARE Plus EV1 SL3 2K** card (NXP MF1PLUS80)
- The 4K layout (40 sectors) is implemented but has not been tested on real hardware


# Extra Requirements

None. No external hardware add-ons, no patched firmware, no extra dependencies. Builds with stock uFBT and runs on any Flipper Zero with firmware API 87.1 or newer.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
