### PR TITLE
Update Sub-GHz Scheduler to v3.0

### DIFF
--- a/applications/Sub-GHz/subghz_scheduler/manifest.yml
+++ b/applications/Sub-GHz/subghz_scheduler/manifest.yml
@@ -2,19 +2,21 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/shalebridge/flipper-subghz-scheduler.git
-    commit_sha: 3c760f122036780e80e342486afbaeec17186747
+    commit_sha: 62a526f52870c9b7e6b6f1fa5878d57711523155
 name: "Sub-GHz Scheduler"
 id: "subghz_scheduler"
-version: "2.3"
-description: "Individual *.sub or playlist *.txt files can be used for Sub-GHz interval transmission. Discrete intervals from 1 seconds to 24 hours are selectable, as well as repeating transmissions for individual data. See repo for description of settings and modes."
-short_description: "Send a Sub-GHz signal repeatedly at a given interval."
+version: "3.0"
+description: "Individual *.sub or playlist *.txt files can be used for Sub-GHz interval transmission, with settings saveable for later use. Schedule intervals in H:M:S format from 00:00:01 to 99:59:59. See repo for description of settings and modes."
+short_description: "Send a single or repeated Sub-GHz signal at a given interval."
 changelog: "@CHANGELOG.md"
 author: "Patrick Edwards"
 targets: ['all']
 category: "Sub-GHz"
 icon: "icons/icon.png"
 screenshots:
-  - "./screenshots/v2.3/rundisplay.png"
-  - "./screenshots/v2.3/intervals.png"
-  - "./screenshots/v2.3/radio.png"
-  - "./screenshots/v2.3/txmode.png"
+  - "./screenshots/v3/rundisplay.png"
+  - "./screenshots/v3/intervals.png"
+  - "./screenshots/v3/main.png"
+  - "./screenshots/v3/radio.png"
+  - "./screenshots/v3/txmode.png"
+  - "./screenshots/v3/saveschedule.png"


### PR DESCRIPTION
# Application Submission

## New Features
- New top level menu:
  - `New Schedule` -- Opens schedule edit window.
  - `Load Schedule` -- Loads schedule settings from a custom file.
  - `About` -- General info.
- Creates `subghz_scheduler` app folder for saving files.
- Edit menu now has `Save Schedule` option to save settings.
- Add custom filetypes for settings and future enhancements.
- Interval is now H:M:S customizable instead of preset, from 00:00:01 to 99:59:59.
- TX Delay is now customizable in 50ms increments from 0-1000ms.
## Bug-fix
- Code cleanup and stability improvements.

# Extra Requirements 

- None

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
