### PR TITLE
Update dcf77 source to arha/flipper-dcf77 v2.0

### DIFF
--- a/applications/Tools/dcf77/manifest.yml
+++ b/applications/Tools/dcf77/manifest.yml
@@ -1,11 +1,13 @@
 sourcecode:
   type: git
   location:
-    origin: https://github.com/xMasterX/all-the-plugins.git
-    commit_sha: 1066d17ad1e8fbf75cea5c6612d79ba539ec8a33
-    subdir: apps_source_code/flipper-dcf77
-description: "Sends the DCF77 time signal (badly) on the 125khz LFRFID antenna and on GPIO C3 pin"
-changelog: "v1.0 - Initial release, v1.1 - Various important fixes, v1.2 - Fixes for latest API, v1.3 - Sync updates and latest API support, v1.4 - Sync with latest version"
-author: "@arha & @xMasterX"
+    origin: https://github.com/arha/flipper-dcf77.git
+    commit_sha: d66ae61045bc42add0f381fa42b11688494ab709
+description: "@docs/catalog/README.md"
+changelog: "@docs/changelog.md"
 screenshots:
-  - "./img/1.png"
+  - docs/1.png
+  - docs/2.png
+  - docs/3.png
+  - docs/4.png
+  - docs/5.png


### PR DESCRIPTION
  # Application Submission

  - Update the existing `dcf77` catalog entry to use the upstream standalone repository `arha/flipper-dcf77` instead of the downstream monorepo copy.
  - This submission is version `2.0`.
  - `dcf77` is a radio clock emulator / debugging tool with DCF77 support plus other OOK time-signal protocols, with LF and SubGHz debug output, plus debugging tools like slowing down time or moving backwards.
  - The catalog manifest now pulls the app metadata from `application.fam`, and the description/changelog/screenshots from the source repository.
  - I am the original upstream author and current maintainer of `arha/flipper-dcf77`, and this PR updates the catalog entry to point to that maintained upstream repository as the canonical source for the app.
  - The copy currently embedded in `all-the-plugins` is better understood as a downstream compatibility snapshot than as the maintained upstream source. It no longer reflects the app's current feature set closely
  enough to serve as the canonical repository for users or maintainers.
  - In particular, the downstream copy differs in hardware behavior and exposed functionality, including missing SubGHz/RF output support and reduced LF frequency configurability. Those differences matter in
  practice because receiver behavior varies depending on how the LF signal is driven, so linking the catalog entry to the maintained upstream repository gives users and downstream maintainers a more accurate
  reference for the current app.

  # Extra Requirements

  - No extra hardware is required to launch the app.
  - Optional: radio clocks / receivers / external antennas / SubGHz receiver gear for testing transmitted or debug output.

  # Author Checklist (Fill this out)

  - [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
  - [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`
  - [X] I own the code I'm submitting or have code owner's permission to submit it

  # Reviewer Checklist (Don't fill this out)

  - [x] Bundle is valid
  - [x] There are no obvious issues with the source code
  - [x] I've ran this application and verified its functionality