### PR TITLE
Add Avocado Zero (Games) catalog manifest

### DIFF
--- a/applications/Games/flipper_avocado_zero/manifest.yml
+++ b/applications/Games/flipper_avocado_zero/manifest.yml
@@ -1,0 +1,29 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Endika/flipper-avocado-zero.git
+    commit_sha: 469f24891ec0fccc0212267b8aa6c2e39018000f
+short_description: "Avocado pit care sim: clean water, grow roots, avoid grime."
+description: |
+  ## Avocado Zero
+
+  A tiny **care sim** for Flipper Zero: you suspend an avocado pit over a glass of water (toothpicks and all) and try to keep it alive long enough to grow a full root system. Time passes, the water gets murky, and if you neglect it for too long—game over.
+
+  ## How to play
+
+  - **Clean** the glass when the water is dirty so your pit stays healthy. Cleaning when it really needs it helps the roots grow.
+  - **Days** tick by in real time; dirt builds up if you stay away too long.
+  - **Win** when the roots reach their full length—then you can start a fresh pit and do it again.
+  - If the water gets **too dry or too filthy**, it is **game over**; hit **Start** to try again from the beginning.
+changelog: |
+  **0.1.0** — First stable release.
+author: Endika
+name: Avocado Zero
+version: 0.1.0
+id: "flipper_avocado_zero"
+category: "Games"
+targets: ["all"]
+screenshots:
+  - "assets/clean.png"
+  - "assets/roots.png"
+  - "assets/game_over.png"


### PR DESCRIPTION
# Application Submission

- Added **Avocado Zero** (`flipper_avocado_zero`), a small care-sim game for Flipper Zero.
- Main gameplay loop:
  - Keep the avocado pit alive by cleaning dirty water.
  - Time progression increases dirtiness while away.
  - Root growth progresses when the pit is well maintained.
  - Win condition when roots reach full growth; lose condition if water becomes too poor.
- Included app metadata updates for catalog submission:
  - Complete manifest fields (name, author, version, category, descriptions, changelog, screenshots).
  - Repository + pinned `commit_sha` for reproducible builds.


# Extra Requirements 

- No extra hardware required.
- No extra software required beyond standard Flipper Zero external app support (built with `ufbt`).

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
