### PR TITLE
Add HyperFocus Calc catalog manifest (Tools)

### DIFF
--- a/applications/Tools/flipper_hyper_focus_calc/manifest.yml
+++ b/applications/Tools/flipper_hyper_focus_calc/manifest.yml
@@ -1,0 +1,19 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Endika/flipper-hyper-focus-calc.git
+    commit_sha: 62c69963f294b45be5fdcc87726109eb1b73b5b7
+short_description: Hyperfocal calculator for Flipper Zero — focal length, full-stop aperture, and per-sensor circle of confusion (CoC), with optional manual CoC editing.
+description: |
+  HyperFocus Calc computes hyperfocal distance from focal length in millimeters, aperture in standard full stops (1.4, 2, 2.8, 4, 5.6, 8, 11, 16, 22), and a per-sensor circle of confusion (CoC). CoC is derived from sensor width and height using a diagonal divided by 1500 (Zeiss-style rule), or you can set CoC manually with fine steps in the sensor editor. The main screen shows focal length, aperture, CoC, and hyperfocal distance in meters, with a simple camera-to-infinity graphic. You can define multiple sensors, pick the active one, and store data on the SD card. Includes main menu, sensor list and editor, text input for names, and a credits screen with version and repository link.
+author: Endika
+version: 0.1.1
+changelog: |
+  - v0.1.1: Documentation and catalog manifest updates.
+  - v0.1.0: Initial release — hyperfocal calculator, per-sensor CoC storage, sensor editor with decimal W/H and CoC, credits screen, host tests and CI.
+category: Tools
+id: flipper_hyper_focus_calc
+name: HyperFocus Calc
+screenshots:
+  - assets/menu.png
+  - assets/hyperfocal.png

--- a/applications/Tools/flipper_hyper_focus_calc/manifest.yml
+++ b/applications/Tools/flipper_hyper_focus_calc/manifest.yml
@@ -2,13 +2,14 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Endika/flipper-hyper-focus-calc.git
-    commit_sha: 62c69963f294b45be5fdcc87726109eb1b73b5b7
+    commit_sha: fcfcb4638b400c1bf89a2431e74f8f118e14d169
 short_description: Hyperfocal calculator for Flipper Zero — focal length, full-stop aperture, and per-sensor circle of confusion (CoC), with optional manual CoC editing.
 description: |
   HyperFocus Calc computes hyperfocal distance from focal length in millimeters, aperture in standard full stops (1.4, 2, 2.8, 4, 5.6, 8, 11, 16, 22), and a per-sensor circle of confusion (CoC). CoC is derived from sensor width and height using a diagonal divided by 1500 (Zeiss-style rule), or you can set CoC manually with fine steps in the sensor editor. The main screen shows focal length, aperture, CoC, and hyperfocal distance in meters, with a simple camera-to-infinity graphic. You can define multiple sensors, pick the active one, and store data on the SD card. Includes main menu, sensor list and editor, text input for names, and a credits screen with version and repository link.
 author: Endika
-version: 0.1.1
+version: 0.1.2
 changelog: |
+  - v0.1.2: Fix UI not refreshing when launched from favorites or desktop quick-launch; the app now forces its own redraws on every screen update.
   - v0.1.1: Documentation and catalog manifest updates.
   - v0.1.0: Initial release — hyperfocal calculator, per-sensor CoC storage, sensor editor with decimal W/H and CoC, credits screen, host tests and CI.
 category: Tools


### PR DESCRIPTION
# Application Submission

HyperFocus Calc is a Flipper Zero utility that computes hyperfocal distance from:

- Focal length (mm), adjusted with D-pad up/down (8–600 mm, 1 mm steps)
- Aperture in standard full-stop steps (1.4 → 22) with left/right
- Circle of confusion (CoC) per sensor: defaults from sensor W × H (mm) via diagonal/1500, with optional manual CoC (0.001 mm steps) in the editor

The main screen shows focal, aperture, CoC, hyperfocal distance in meters, and a simple camera–scene graphic. Sensors are stored on the SD card under /ext/apps_data/hyperfocuscalc/. The app includes a menu (Calculate, My sensors, Credits), sensor list/editor, text input for names, and a credits screen

# Extra Requirements 

- Hardware: none (uses Flipper Zero only).
- Software: none beyond official / compatible firmware; uFBT builds the FAP from the linked GitHub repo.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
