### PR TITLE
Add U2F over NFC app

### DIFF
--- a/applications/NFC/u2f_over_nfc/manifest.yml
+++ b/applications/NFC/u2f_over_nfc/manifest.yml
@@ -1,0 +1,10 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/asaldele1/u2f_over_nfc.git
+    commit_sha: 7b3ae0de78d2e6f65ae3e4b1ceb71df1d5e338df
+description: "@.catalog/README.md"
+changelog: "@CHANGELOG.md"
+screenshots:
+  - ".catalog/screenshots/1.png"
+  - ".catalog/screenshots/2.png"


### PR DESCRIPTION
# Application Submission

This application allows your Flipper Zero to act as a FIDO U2F security key over NFC. You can use it to securely authenticate on supported services just by tapping your Flipper to your phone.


# Extra Requirements 

No

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
