### PR TITLE
Add OSM Logger (GPS POI logger for OSM mapping)

### DIFF
--- a/applications/GPIO/osm_logger/manifest.yml
+++ b/applications/GPIO/osm_logger/manifest.yml
@@ -2,14 +2,14 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/simongrossi/flipperzero-osm-logger-gps.git
-    commit_sha: 374de0875e393b6bcbfdd29641b6747f2212daa7
+    commit_sha: 7391469fcdc5634b0a22b2fc38afd8ba67be3381
     subdir: "."
 description: "@README.md"
 changelog: "@changelog.md"
 author: "@simongrossi"
 screenshots:
   - "./screenshots/01-menu.png"
-  - "./screenshots/02-presets.png"
-  - "./screenshots/03-quicklog.png"
-  - "./screenshots/04-track.png"
-  - "./screenshots/05-status.png"
+  - "./screenshots/03-presets.png"
+  - "./screenshots/04-quicklog.png"
+  - "./screenshots/07-track.png"
+  - "./screenshots/08-last-points.png"

--- a/applications/GPIO/osm_logger/manifest.yml
+++ b/applications/GPIO/osm_logger/manifest.yml
@@ -1,0 +1,15 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/simongrossi/flipperzero-osm-logger-gps.git
+    commit_sha: 374de0875e393b6bcbfdd29641b6747f2212daa7
+    subdir: "."
+description: "@README.md"
+changelog: "@changelog.md"
+author: "@simongrossi"
+screenshots:
+  - "./screenshots/01-menu.png"
+  - "./screenshots/02-presets.png"
+  - "./screenshots/03-quicklog.png"
+  - "./screenshots/04-track.png"
+  - "./screenshots/05-status.png"


### PR DESCRIPTION
# Application Submission

**OSM Logger** — a new Flipper Zero app to log **OpenStreetMap POIs** (bench, waste basket, drinking water, defibrillator, bus stop, playground, …) in the field using an external **NEO-6M GPS** module over UART.

This is a first submission (v0.2).

### Key features

- **Quick Log**: submenu of 23 built-in OSM presets (street furniture, roads, shops, emergency…). Preset variants cyclable with ←/→ (e.g. `amenity=cafe` → `pub` → `bar` → `fast_food`). Short note editor via `Up` (Flipper TextInput). HDOP gate (≤ 2.5) with hold-OK to force.
- **Track mode**: auto-logs a `<trkpt>` every 5 s into a GPX track. New `<trkseg>` per session avoids fake lines between pauses.
- **GPS status view**: live fix, lat/lon, altitude, HDOP, satellites, fix age, NMEA RX counters (bytes/lines) for wiring diagnostics.
- **Notifications**: automatic vibration + green LED when a fix is acquired.
- **Customization without recompiling**: drop a `presets.txt` on the SD (`/ext/apps_data/osm_logger/presets.txt`) to replace the built-in preset list.
- **5 output formats** on SD (all remain valid at any time thanks to write-append-framed): `points.jsonl`, `notes.csv`, `points.gpx`, `points.geojson`, `track.gpx`.
- Works on both **stock and Momentum firmware** (auto-disables the Expansion service to free the UART for GPS data).

Source: https://github.com/simongrossi/flipperzero-osm-logger-gps · License: MIT


# Extra Requirements

**External GPS module required** — any NMEA 0183 module at 9600 bauds, tested with **u-blox NEO-6M V2**. Wiring:

| NEO-6M | Flipper pin |
|--------|-------------|
| VCC    | 9 (3V3)     |
| GND    | 11          |
| TX     | **14** (RX) |

3.3 V only — see [docs/HARDWARE.md](https://github.com/simongrossi/flipperzero-osm-logger-gps/blob/main/docs/HARDWARE.md) for details.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality