### PR TITLE
Add Flipper TV Remote

### DIFF
--- a/applications/Infrared/flipper_tv_remote/manifest.yml
+++ b/applications/Infrared/flipper_tv_remote/manifest.yml
@@ -6,12 +6,9 @@ sourcecode:
 description: "@README.md"
 changelog: "@./docs/changelog.md"
 screenshots:
-  - docs/screenshots/Vertical-Remote.png
   - docs/screenshots/Horizontal-Remote.png
   - docs/screenshots/Menu.png
   - docs/screenshots/Learn-Remote.png
   - docs/screenshots/Learn-Remote-Power.png
   - docs/screenshots/Remote-Selection.png
   - docs/screenshots/Settings.png
-  - docs/screenshots/Veritcal-Remote-Button-Up-Pressed.png
-  - docs/screenshots/Veritcal-Remote-Button-Ok-Pressed.png

--- a/applications/Infrared/flipper_tv_remote/manifest.yml
+++ b/applications/Infrared/flipper_tv_remote/manifest.yml
@@ -1,0 +1,17 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/jmanion0139/flipper_tv_remote.git
+    commit_sha: 58ad2a4191e2d09ee0da95757a0549581fd7145f
+description: "@README.md"
+changelog: "@./docs/changelog.md"
+screenshots:
+  - docs/screenshots/Vertical-Remote.png
+  - docs/screenshots/Horizontal-Remote.png
+  - docs/screenshots/Menu.png
+  - docs/screenshots/Learn-Remote.png
+  - docs/screenshots/Learn-Remote-Power.png
+  - docs/screenshots/Remote-Selection.png
+  - docs/screenshots/Settings.png
+  - docs/screenshots/Veritcal-Remote-Button-Up-Pressed.png
+  - docs/screenshots/Veritcal-Remote-Button-Ok-Pressed.png

--- a/applications/Infrared/flipper_tv_remote/manifest.yml
+++ b/applications/Infrared/flipper_tv_remote/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/jmanion0139/flipper_tv_remote.git
-    commit_sha: 58ad2a4191e2d09ee0da95757a0549581fd7145f
+    commit_sha: 5c3b9587915eaab094c9e9f8ce4c55643027a9bb
 description: "@README.md"
 changelog: "@./docs/changelog.md"
 screenshots:

--- a/applications/Infrared/flipper_tv_remote/manifest.yml
+++ b/applications/Infrared/flipper_tv_remote/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/jmanion0139/flipper_tv_remote.git
-    commit_sha: 5c3b9587915eaab094c9e9f8ce4c55643027a9bb
+    commit_sha: 9ce9d3e90bf684bef77f96927048854659786a3f
 description: "@README.md"
 changelog: "@./docs/changelog.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

- An infrared application which is designed to replace a TV remote. Instead of navigating menus to select what signal to send, 12 signals can be recorded and sent from short or long pressing the D-pad and Back buttons. This allows it to act fully as a TV remote with ease.


# Extra Requirements 

- None


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
