### PR TITLE
Add HabitFlow (flipper_habit_flow) to Apps Catalog under Tools.

### DIFF
--- a/applications/Tools/flipper_habit_flow/manifest.yml
+++ b/applications/Tools/flipper_habit_flow/manifest.yml
@@ -1,0 +1,22 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Endika/flipper-habit-flow.git
+    commit_sha: 6cfbe2100bb203233c15895cf52226aaf1ad6561
+short_description: Offline habit tracker for Flipper Zero — goals, streaks, progress, automatic saves, and optional prompts when the calendar advances.
+description: |
+  HabitFlow runs entirely on the device: name your habits, set a day-based goal (1–365, default 66), mark today complete, and follow streaks and your best run toward mastery. Changes are saved automatically. When the date moves forward, the app can ask whether you finished yesterday so streaks update in a clear way instead of dropping silently.
+
+  ## Features
+
+  - Dashboard with scrollable habits and a compact recent-activity strip per habit (filled = done, frame = missed).
+  - Detail view with progress, streak and record streak, optional medal after mastery, OK to toggle today, Up to reset streak (with confirm).
+  - Manage habits from the dashboard (Left): add, edit name and goal, save, delete.
+  - Launch handling for calendar gaps: a one-day gap with unfinished yesterday opens Yes/No per habit; longer gaps reset streaks and clear the strip.
+author: Endika
+version: 0.1.2
+changelog: |
+  - Initial catalog listing: habit list, detail, manage/edit, automatic saves, session and yesterday flow.
+screenshots:
+  - assets/main.png
+  - assets/habit.png

--- a/applications/Tools/flipper_habit_flow/manifest.yml
+++ b/applications/Tools/flipper_habit_flow/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Endika/flipper-habit-flow.git
-    commit_sha: 6cfbe2100bb203233c15895cf52226aaf1ad6561
+    commit_sha: 3063417ac6dae340398a8434968a1f01906f594e
 short_description: Offline habit tracker for Flipper Zero — goals, streaks, progress, automatic saves, and optional prompts when the calendar advances.
 description: |
   HabitFlow runs entirely on the device: name your habits, set a day-based goal (1–365, default 66), mark today complete, and follow streaks and your best run toward mastery. Changes are saved automatically. When the date moves forward, the app can ask whether you finished yesterday so streaks update in a clear way instead of dropping silently.
@@ -14,8 +14,12 @@ description: |
   - Manage habits from the dashboard (Left): add, edit name and goal, save, delete.
   - Launch handling for calendar gaps: a one-day gap with unfinished yesterday opens Yes/No per habit; longer gaps reset streaks and clear the strip.
 author: Endika
-version: 0.1.2
+version: 0.1.3
 changelog: |
+  ## 0.1.3
+  - Fix UI not refreshing when the app is opened from favorites or the desktop quick-launch buttons; the app now forces its own redraws on every screen update instead of relying on the launcher animation.
+
+  ## 0.1.2
   - Initial catalog listing: habit list, detail, manage/edit, automatic saves, session and yesterday flow.
 screenshots:
   - assets/main.png


### PR DESCRIPTION
# Application Submission

**HabitFlow** is an offline habit tracker for Flipper Zero. You define habits with a day-based goal (1–365 days, default 66), mark today as done from the device, and see streaks, your record streak, and progress toward mastery.

When the calendar advances, the app can walk through a short “did you finish yesterday?” flow so streaks update in a deliberate way; longer gaps without opening the app are handled according to the rules described in the README.

**This submission:** first listing of HabitFlow in the Apps Catalog (`applications/Tools/flipper_habit_flow/manifest.yml`), targeting source commit `6cfbe2100bb203233c15895cf52226aaf1ad6561` on `https://github.com/Endika/flipper-habit-flow` (version **0.1.2** per `application.fam`).


# Extra Requirements 

- **Hardware:** none beyond a stock Flipper Zero (no GPIO, Sub-GHz, NFC, etc.).
- **Software:** none beyond installing the `.fap` from the catalog; data is stored automatically in the device app data area (no PC or phone required for normal use).


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
