### PR TITLE
Add Disney Toolbox app

### DIFF
--- a/applications/Tools/disney_toolbox/README.md
+++ b/applications/Tools/disney_toolbox/README.md
@@ -1,0 +1,5 @@
+# Disney Toolbox
+
+Toolbox for Disney park tech, including Kyber crystal writer and MagicBand+ beacon emulator.
+
+GitLab Repo: https://gitlab.com/Nathaniel.Belles/flipper-disney-toolbox

--- a/applications/Tools/disney_toolbox/manifest.yml
+++ b/applications/Tools/disney_toolbox/manifest.yml
@@ -1,0 +1,15 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://gitlab.com/Nathaniel.Belles/flipper-disney-toolbox.git
+    commit_sha: d9aa1fa8af9e0222da59ed16481d967619850b42
+description: "@docs/catalog_description.md"
+changelog: "@CHANGELOG"
+screenshots:
+  - "docs/Homepage.png"
+  - "docs/Kyber Crystal.png"
+  - "docs/Kyber Crystal Selection.png"
+  - "docs/Kyber Crystal Writer.png"
+  - "docs/MagicBand+ Beacon.png"
+  - "docs/MagicBand+ Beacon Selection.png"
+  - "docs/MagicBand+ Beacon Broadcasting.png"


### PR DESCRIPTION
# Application Submission

- Toolbox for Disney park tech, including Kyber crystal writer and MagicBand+ beacon emulator.
- See full [README](https://gitlab.com/Nathaniel.Belles/flipper-disney-toolbox/-/blob/main/README.md) for more information on the app, it's functionality and usage

# Extra Requirements 

- No required hardware but useful to have access to Kyber crystals or a MagicBand+

# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
