### PR TITLE
Add ZeroMesh - Meshtastic serial interface for Flipper Zero

### DIFF
--- a/applications/GPIO/zeromesh/manifest.yml
+++ b/applications/GPIO/zeromesh/manifest.yml
@@ -1,0 +1,17 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/SAMS0N1TE/ZeroMesh.git
+    commit_sha: df0558610952e5e2ee406d6b2494cd2e08b83eec
+
+short_description: Meshtastic serial interface for Flipper Zero
+
+description: "@README.md"
+
+changelog: "@changelog.md"
+
+screenshots:
+  - docs/images/messages.png
+  - docs/images/roster.png
+  - docs/images/chat.png
+  - docs/images/settings.png


### PR DESCRIPTION
# Application Submission

- ZeroMesh is a Meshtastic serial interface for the Flipper Zero. Connects to a Meshtastic node via UART and provides live mesh monitoring, node roster with SNR/RSSI/telemetry, broadcast and direct messaging, multi-channel support (up to 8 channels), configurable notifications (vibration, LED, 19 ringtones), and persistent settings saved to SD card. 


# Extra Requirements 

- Requires a Meshtastic node connected via UART to the Flipper Zero GPIO pins. Node must have Serial Module enabled with mode set to PROTO and baud rate 115200.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
