### PR TITLE
Add aprstx manifest

### DIFF
--- a/applications/Sub-GHz/aprstx/manifest.yml
+++ b/applications/Sub-GHz/aprstx/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/yo3gnd/flipper-zero-aprs-tx
-    commit_sha: 4a90539388920ee28b0fb1a5b96765a6f0aaf380
+    commit_sha: 1558ee46619b20d97f937a32849ac887c9e192eb
 description: "@README-MARKET.md"
 changelog: "@CHANGELOG-MARKET.md"
 screenshots:

--- a/applications/Tools/aprstx/manifest.yml
+++ b/applications/Tools/aprstx/manifest.yml
@@ -1,0 +1,13 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/yo3gnd/flipper-zero-aprs-tx
+    commit_sha: 4a90539388920ee28b0fb1a5b96765a6f0aaf380
+description: "@README-MARKET.md"
+changelog: "@CHANGELOG-MARKET.md"
+screenshots:
+  - docs/pics/Screenshot-20231015-082151.png
+  - docs/pics/Screenshot-20231015-082145.png
+  - docs/pics/Screenshot-20260424-130712.png
+  - docs/pics/Screenshot-20231015-082119.png
+  - docs/pics/Screenshot-20231015-082113.png


### PR DESCRIPTION
# Application Submission

-  Flipper ham APRS TX is an experimental APRS / AX.25 transmitter for Flipper Zero. It does not use the Flipper as an audio source for another radio; it drives the Sub-GHz hardware directly and produces something APRS-like using only the device itself. The app can send APRS messages, status packets, bulletins, and fixed-position packets. It also keeps a small destination callbook, remembers settings, and exposes a few RF-side controls for coaxing receivers into decoding it. This is its first submission to the catalog.

# Extra Requirements 

- No extra hardware is required to run the app itself. To receive or decode packets, you will need something listening on a suitable frequency, such as a handheld, SDR, software decoder or gateway such as Direwolf. The app is still experimental, receiver-dependent, and subject to the usual legal restrictions on transmission in the relevant bands.

# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
