### PR TITLE
Add NFC Tools

### DIFF
--- a/applications/NFC/nfc_tools/manifest.yml
+++ b/applications/NFC/nfc_tools/manifest.yml
@@ -1,0 +1,25 @@
+author: "Wakdev"
+category: "NFC"
+changelog: "@changelog.md"
+description: "@README.md"
+icon: "icons/icon.png"
+id: "nfc_tools"
+name: "NFC Tools"
+
+screenshots:
+  - screenshots/screenshot_01.png
+  - screenshots/screenshot_02.png
+  - screenshots/screenshot_03.png
+  - screenshots/screenshot_04.png
+  - screenshots/screenshot_05.png
+  - screenshots/screenshot_06.png
+
+short_description: NFC Tools can read and write your NFC tags
+
+sourcecode:
+  location:
+    commit_sha: 81c1aac74b6fdba39c5625115671345299174273
+    origin: https://github.com/wakdev/nfctools-fz
+  type: git
+
+version: 1.0

--- a/applications/NFC/nfc_tools/manifest.yml
+++ b/applications/NFC/nfc_tools/manifest.yml
@@ -18,8 +18,8 @@ short_description: NFC Tools can read and write your NFC tags
 
 sourcecode:
   location:
-    commit_sha: 81c1aac74b6fdba39c5625115671345299174273
+    commit_sha: 41eeb4fcc8cfc1a79642b7cffd2c5b8848f0d6d4
     origin: https://github.com/wakdev/nfctools-fz
   type: git
 
-version: 1.0
+version: 1.1

--- a/applications/NFC/nfc_tools/manifest.yml
+++ b/applications/NFC/nfc_tools/manifest.yml
@@ -18,8 +18,8 @@ short_description: NFC Tools can read and write your NFC tags
 
 sourcecode:
   location:
-    commit_sha: 41eeb4fcc8cfc1a79642b7cffd2c5b8848f0d6d4
+    commit_sha: b36c5f31cf2f2f595bd27b7ad6fab1fd919e7249
     origin: https://github.com/wakdev/nfctools-fz
   type: git
 
-version: 1.1
+version: 1.2


### PR DESCRIPTION
# Application Submission

NFC Tools for Flipper Zero is a port of the popular NFC Tools application available on Android, iOS, and PC/Mac.
Read and write NFC tags anywhere, with an interface designed to stay simple and intuitive on the Flipper's small screen.

# Extra Requirements 

Obviously, some compatible NFC Chips like NTAG21x chips.

# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
