### PR TITLE
Add TriviaZero (flipper_trivia_zero) to Apps Catalog under Games.

### DIFF
--- a/applications/Games/flipper_trivia_zero/manifest.yml
+++ b/applications/Games/flipper_trivia_zero/manifest.yml
@@ -1,0 +1,23 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Endika/flipper-trivia-zero.git
+    commit_sha: 1e22cbc2591393a26f3405bfc4c0f870154bdd9a
+short_description: "Bilingual flashcard trivia: random questions with reveal-on-OK, two languages shipped."
+description: |
+  Trivia Zero is a bilingual flashcard trivia application for Flipper Zero. It shows random questions one at a time and reveals the answer when you press OK, with anti-repeat history so you don't see the same question twice in a row. The app ships with two embedded question packs (English and Spanish), no SD card copy required, and stores user settings persistently across sessions.
+author: Endika
+version: 0.1.12
+changelog: |
+  0.1.12
+  - pack: curate multiple questions
+  - pack: curate questions
+  0.1.11
+  - pack: drop questions with multiple-choice phrasing
+  0.1.10
+  - pack: curate questions
+  0.1.9
+  - Initial release
+screenshots:
+  - assets/screen1.png
+  - assets/screen2.png


### PR DESCRIPTION
# Application Submission

Trivia Zero — bilingual flashcard trivia for Flipper Zero.

  - Random questions one at a time, OK reveals the answer (no multiple choice).
  - Two embedded question packs (English/Spanish), no SD card copy needed.
  - Anti-repeat history buffer so the same question doesn't show twice in a row.
  - Persistent settings storage (language, etc.) across sessions.

  Repo: https://github.com/Endika/flipper-trivia-zero — submission pinned to tag `v0.1.12`
  (commit `1e22cbc`).


# Extra Requirements 

-   None. No extra hardware, no SD card content; question packs ship embedded in the FAP binary.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
