### PR TITLE
Add NFC stock (flipper_nfc_stock) to Apps Catalog under NFC.

### DIFF
--- a/applications/NFC/nfc_stock_manager/manifest.yml
+++ b/applications/NFC/nfc_stock_manager/manifest.yml
@@ -1,0 +1,25 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Endika/flipper-nfc-stock.git
+    commit_sha: 9ae89cceea14d5ee0b8250a7c2fded2a70f678d5
+short_description: "NFC-based inventory: scan a tag to open or create an item, edit stock, location and minimum, with multi-warehouse DB and CSV export."
+description: |
+  NFC Stock Manager turns your Flipper Zero into a portable inventory tool. Scan an NFC tag to open the matching item or create a new one on the fly, then edit its stock, minimum stock and location directly from the device. Items are stored in compact .bin databases and can be exported to .csv for easy backup or sharing. Multiple warehouses are supported: switch between databases, create new ones, or rename the active one from Settings.
+author: Endika
+version: 0.1.5
+changelog: |
+  0.1.5
+  - fix(app): resolve fam errors
+  0.1.4
+  - fix: update scanner scene
+  0.1.3
+  - feat: improve stability, warehouse DB management, and CSV export UX
+  0.1.2
+  - fix(ci): upload fix
+  0.1.1
+  - feat(init): initial release
+screenshots:
+  - assets/menu.png
+  - assets/items.png
+  - assets/details.png


### PR DESCRIPTION
# Application Submission

- NFC Stock Manager — a portable inventory tool for Flipper Zero based on NFC tags.

  - Scan an NFC tag to open the matching item, or create a new one if the UID is unknown.
  - Edit stock, minimum stock and location directly from the device.
  - Multi-warehouse support: switch, create or rename `.bin` databases from Settings.
  - CSV export of the active database.
  - Data stored under `/ext/apps_data/nfc_stock_manager`.

  This is the initial submission of the application (v0.1.5).


# Extra Requirements 

- None. The application uses only the built-in NFC reader of the Flipper Zero and the SD
  card for persistence. No extra hardware or software is required.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`


# Reviewer Checklist (Don't fill this out)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
