### PR TITLE
Add SSD1306 Test app (GPIO)

### DIFF
--- a/applications/GPIO/ssd1306_test/manifest.yml
+++ b/applications/GPIO/ssd1306_test/manifest.yml
@@ -2,9 +2,9 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/martinbogo/ssd1306_test.git
-    commit_sha: 8d902998bc15fe0c05a7fccec6802e11787149bc
+    commit_sha: c6ae307116e06bb1019fe175214a4ccb3c08d4f1
 short_description: "Diagnostic tool for SSD1306 I2C OLED displays (128x64, yellow-bar and mono variants)"
-description: "@README.md"
+description: "@DESCRIPTION.md"
 changelog: "@CHANGELOG.md"
 screenshots:
   - screenshots/screen1.png

--- a/applications/GPIO/ssd1306_test/manifest.yml
+++ b/applications/GPIO/ssd1306_test/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/martinbogo/ssd1306_test.git
-    commit_sha: 40ab571009c8ea3a9383e2e32c2d0275095e5ae5
+    commit_sha: fb4bce64216627c4df269f00502c6af4345093ed
 short_description: "Diagnostic tool for SSD1306 I2C OLED displays (128x64, yellow-bar and mono variants)"
 description: "@README.md"
 changelog: "@CHANGELOG.md"

--- a/applications/GPIO/ssd1306_test/manifest.yml
+++ b/applications/GPIO/ssd1306_test/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/martinbogo/ssd1306_test.git
-    commit_sha: fb4bce64216627c4df269f00502c6af4345093ed
+    commit_sha: 1bf6e11c146ade46763fa442ef92fa8034a06794
 short_description: "Diagnostic tool for SSD1306 I2C OLED displays (128x64, yellow-bar and mono variants)"
 description: "@README.md"
 changelog: "@CHANGELOG.md"

--- a/applications/GPIO/ssd1306_test/manifest.yml
+++ b/applications/GPIO/ssd1306_test/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/martinbogo/ssd1306_test.git
-    commit_sha: 4a692191ef57353fb84900908b955cf2f6a45ba7
+    commit_sha: 8d902998bc15fe0c05a7fccec6802e11787149bc
 short_description: "Diagnostic tool for SSD1306 I2C OLED displays (128x64, yellow-bar and mono variants)"
 description: "@README.md"
 changelog: "@CHANGELOG.md"

--- a/applications/GPIO/ssd1306_test/manifest.yml
+++ b/applications/GPIO/ssd1306_test/manifest.yml
@@ -1,0 +1,10 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/martinbogo/ssd1306_test.git
+    commit_sha: 40ab571009c8ea3a9383e2e32c2d0275095e5ae5
+short_description: "Diagnostic tool for SSD1306 I2C OLED displays (128x64, yellow-bar and mono variants)"
+description: "@README.md"
+changelog: "@CHANGELOG.md"
+screenshots:
+  - screenshots/screen1.png

--- a/applications/GPIO/ssd1306_test/manifest.yml
+++ b/applications/GPIO/ssd1306_test/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/martinbogo/ssd1306_test.git
-    commit_sha: 1bf6e11c146ade46763fa442ef92fa8034a06794
+    commit_sha: 4a692191ef57353fb84900908b955cf2f6a45ba7
 short_description: "Diagnostic tool for SSD1306 I2C OLED displays (128x64, yellow-bar and mono variants)"
 description: "@README.md"
 changelog: "@CHANGELOG.md"


### PR DESCRIPTION
## Summary
- Adds **SSD1306 Test**, a diagnostic tool for external SSD1306-based 128x64 I2C OLED displays connected via the Flipper Zero GPIO header
- Category: GPIO
- App ID: `ssd1306_test`
- Source: https://github.com/martinbogo/ssd1306_test

## App Features
- Clock + Status Board with large 7-segment digits, battery, date, and device name
- 10 test patterns (all white/black, checkerboard, gradient, color zone test, etc.)
- Brightness/contrast control (0-255)
- Display command toggles (invert, flip H/V, force all pixels, power on/off)
- Hardware scrolling (horizontal, diagonal, adjustable speed)
- Display info with live I2C connection status
- Auto-detects I2C address (0x3C and 0x3D)
- Supports both monochrome and yellow-bar (dual-color) SSD1306 variants

## Checklist
- [x] App builds with ufbt against latest release SDK
- [x] `application.fam` contains appid, name, fap_category, fap_version, fap_author, fap_icon
- [x] Source repo contains README.md, CHANGELOG.md, and screenshots
- [x] Screenshot taken with qFlipper
- [x] App is open source (MIT license)
- [x] manifest.yml references a specific commit SHA