### PR TITLE
Add CK42X PassVault app

### DIFF
--- a/applications/Tools/ck42x_passvault/README.md
+++ b/applications/Tools/ck42x_passvault/README.md
@@ -1,0 +1,5 @@
+# CK42X PassVault
+
+Catalog manifest for [CK42X PassVault](https://github.com/lordbuffcloud/flipper-ck42x-passvault), a Flipper Zero external app for small field credentials, memorable password generation, and explicit opt-in USB HID password typing.
+
+Security note: v0.2 stores entries as plaintext TSV in app data. It is intended as a field utility/prototype, not a hardened password manager for high-value secrets.

--- a/applications/Tools/ck42x_passvault/README.md
+++ b/applications/Tools/ck42x_passvault/README.md
@@ -1,5 +1,5 @@
 # CK42X PassVault
 
-Catalog manifest for [CK42X PassVault](https://github.com/lordbuffcloud/flipper-ck42x-passvault), a Flipper Zero external app for small field credentials, memorable password generation, and explicit opt-in USB HID password typing.
+Catalog manifest for [CK42X PassVault](https://github.com/lordbuffcloud/flipper-ck42x-passvault), a Flipper Zero external app for PIN-gated encrypted password storage, RNG password generation, and explicit opt-in USB HID password typing.
 
-Security note: v0.2 stores entries as plaintext TSV in app data. It is intended as a field utility/prototype, not a hardened password manager for high-value secrets.
+Security note: v0.4 stores the active vault as AES-GCM encrypted app data and requires a master PIN, but it is still an unaudited Flipper utility. A compromised device, weak PIN, shoulder surfing, debug access, or modified firmware can still expose vault contents.

--- a/applications/Tools/ck42x_passvault/manifest.yml
+++ b/applications/Tools/ck42x_passvault/manifest.yml
@@ -2,8 +2,8 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/lordbuffcloud/flipper-ck42x-passvault.git
-    commit_sha: 550a4ae60c35e4ec04031b4d741ba80b027a32f4
-short_description: CK42X.com field password vault with memorable generator and opt-in HID password typing.
+    commit_sha: 49386a7ddb9c489339af3544f66f17a50e6f2e14
+short_description: CK42X.com password vault with RNG generation and opt-in HID password typing.
 description: "@catalog_description.md"
 changelog: "@catalog_changelog.md"
 screenshots:

--- a/applications/Tools/ck42x_passvault/manifest.yml
+++ b/applications/Tools/ck42x_passvault/manifest.yml
@@ -1,0 +1,10 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/lordbuffcloud/flipper-ck42x-passvault.git
+    commit_sha: 550a4ae60c35e4ec04031b4d741ba80b027a32f4
+short_description: CK42X.com field password vault with memorable generator and opt-in HID password typing.
+description: "@catalog_description.md"
+changelog: "@catalog_changelog.md"
+screenshots:
+  - screenshots/ck42x-passvault-main.png

--- a/applications/Tools/ck42x_passvault/manifest.yml
+++ b/applications/Tools/ck42x_passvault/manifest.yml
@@ -2,8 +2,8 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/lordbuffcloud/flipper-ck42x-passvault.git
-    commit_sha: 49386a7ddb9c489339af3544f66f17a50e6f2e14
-short_description: CK42X.com password vault with RNG generation and opt-in HID password typing.
+    commit_sha: b51e3a71316b0e3d4fa3e52018c41113b805ef7b
+short_description: CK42X.com PIN-gated encrypted password vault with RNG generation and opt-in HID password typing.
 description: "@catalog_description.md"
 changelog: "@catalog_changelog.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

- Updates CK42X PassVault, a Flipper Zero app for storing a short local list of account entries, generating random passwords, and HID-typing a selected password only after explicit Flipper confirmation.

## What changed in v0.4

- Added master PIN setup/unlock before vault access.
- Stores the active vault as AES-GCM encrypted app data in `vault.pv1`.
- Uses PIN-derived key material with a per-vault random salt and a fresh random AES-GCM nonce on each save.
- Migrates legacy plaintext `vault.tsv` once after PIN setup, then removes it after encrypted save succeeds.
- Keeps generated passwords random via Flipper RNG and unique within the current saved vault entries.

## Checklist

- [x] I read and followed the application catalog contribution requirements.
- [x] The application source is public: https://github.com/lordbuffcloud/flipper-ck42x-passvault
- [x] `application.fam` includes a unique app id: `ck42x_passvault`.
- [x] App category is `Tools`.
- [x] App builds with uFBT against current release SDK.
- [x] Manifest uses a stable source commit SHA.
- [x] Catalog description and changelog are included.
- [x] Screenshot is included.

## Testing

- Built with uFBT.
- uFBT appcheck passed: Target 7, API 87.1.
- Ran password preset shape test.
- Catalog bundle validation passed locally with `tools/bundle.py --nolint`.

## Security wording

PassVault is described as a small Flipper password tool, not a hardened audited password manager. v0.4 encrypts the active vault and gates access behind a master PIN, but the public copy avoids overclaiming stronger trust than the implementation supports.
