### PR TITLE
Add Pocket CVSS v0.3

### DIFF
--- a/applications/Tools/pocket_cvss/manifest.yml
+++ b/applications/Tools/pocket_cvss/manifest.yml
@@ -1,0 +1,12 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/vavkamil/pocket-cvss.git
+    commit_sha: c911a5f7aa41f2338d019443f4f48ecc448a33f2
+description: "@.catalog/README.md"
+changelog: "@CHANGELOG.md"
+screenshots:
+  - screenshots/01_result.png
+  - screenshots/02_severity.png
+  - screenshots/03_examples.png
+  - screenshots/04_menu.png

--- a/applications/Tools/pocket_cvss/manifest.yml
+++ b/applications/Tools/pocket_cvss/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/vavkamil/pocket-cvss.git
-    commit_sha: c911a5f7aa41f2338d019443f4f48ecc448a33f2
+    commit_sha: b8aaace66063e6d3ed551b6f28e70580fbc58d22
 description: "@.catalog/README.md"
 changelog: "@CHANGELOG.md"
 screenshots:

--- a/applications/Tools/pocket_cvss/manifest.yml
+++ b/applications/Tools/pocket_cvss/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/vavkamil/pocket-cvss.git
-    commit_sha: b8aaace66063e6d3ed551b6f28e70580fbc58d22
+    commit_sha: c911a5f7aa41f2338d019443f4f48ecc448a33f2
 description: "@.catalog/README.md"
 changelog: "@CHANGELOG.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

- Pocket CVSS is an offline CVSS v3.1 base score calculator for Flipper Zero.
- It calculates severity, shows the vector, includes example vectors, and has a severity reference.
- v0.3 includes UI polish and layout cleanup.

# Extra Requirements 

- No extra hardware or software is required.
- The app runs fully offline on Flipper Zero.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with 
-  `python3 tools/bundle.py --nolint applications/Tools/pocket_cvss/
  manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

## Explanation

- The Pocket CVSS source was generated with AI under my direction and review.
- The app separates CVSS scoring logic from the Flipper UI.
- Standalone C tests cover the CVSS logic.
- CI runs tests, format/lint checks, and uFBT release-channel builds.
- GitHub Actions are pinned, and workflows use minimal permissions.

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
