### PR TITLE
Add Bluetooth Bridge (`bluetooth_bridge`) app

### DIFF
--- a/applications/Bluetooth/bluetooth_bridge/manifest.yml
+++ b/applications/Bluetooth/bluetooth_bridge/manifest.yml
@@ -1,0 +1,10 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/excitoon/zero-bluetooth-bridge.git
+    commit_sha: 57e32684bae3beb370a0b384855f82251f0c51a8
+short_description: "Remote management of Flipper Zero over Bluetooth"
+description: "@README.md"
+changelog: "@docs/changelog.md"
+screenshots:
+- screenshots/ss0.png


### PR DESCRIPTION
# Application Submission

Bluetooth Bridge for Flipper Zero — wirelessly bridges BLE serial (phone) to GPIO UART, enabling remote control of serial devices like ESP32 Marauder, GPS modules, and other UART peripherals directly from a phone.

Features:
- Bridges BLE serial ↔ GPIO UART (USART1, 115200 8N1)
- Live byte counter on screen
- Battery level reporting via BLE Battery Service
- OTA self-update over BLE (no USB needed to update the app)
- One-time pairing, stored permanently

# Extra Requirements 

Requires a UART device connected to Flipper GPIO (pins 13/14, TX/RX). Tested with ESP32 running Marauder firmware.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

AI assisted with CI/CD workflow, screenshot generation, and catalog manifest. Core application logic written by the author.

# Reviewer Checklist (Don't fill this out!)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
