### PR TITLE
Add CK42X Payload Bay app

### DIFF
--- a/applications/USB/ck42x_payload_bay/README.md
+++ b/applications/USB/ck42x_payload_bay/README.md
@@ -1,0 +1,7 @@
+# CK42X Payload Bay
+
+Catalog manifest for [CK42X Payload Bay](https://github.com/lordbuffcloud/flipper-ck42x-payload-bay), a Flipper Zero USB training launcher for authorized labs.
+
+The app loads one reviewed `.txt` payload from `/ext/ck42x-payloads`, runs it through a small built-in HID runner, and can open a Mass Storage companion image for artifact write-back.
+
+Payload files are not included with the app. Operators must use it only on systems they own or have written permission to test.

--- a/applications/USB/ck42x_payload_bay/manifest.yml
+++ b/applications/USB/ck42x_payload_bay/manifest.yml
@@ -1,0 +1,10 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/lordbuffcloud/flipper-ck42x-payload-bay.git
+    commit_sha: 4c890079a250da4686e6cd1a67dfbb0460a3c620
+short_description: Authorized USB payload training launcher for Flipper Zero.
+description: "@catalog_description.md"
+changelog: "@changelog.md"
+screenshots:
+  - screenshots/payload-bay-main.png


### PR DESCRIPTION
## Summary
- Adds CK42X Payload Bay to the USB category.
- Source repository: https://github.com/lordbuffcloud/flipper-ck42x-payload-bay
- App id: ck42x_payload_bay
- Version: 0.4

## Validation
- Built the source app with uFBT: Target 7, API 87.1
- Ran catalog bundle validation:
  - `python tools/bundle.py --nolint applications/USB/ck42x_payload_bay/manifest.yml /tmp/ck42x_payload_bay_bundle.zip`

## Notes
- The app does not include payload files.
- It is documented for owned systems and written-authorized lab use.
