### PR TITLE
Add CK42X DopeFlipper app

### DIFF
--- a/applications/Games/ck42x_dopewars/README.md
+++ b/applications/Games/ck42x_dopewars/README.md
@@ -1,0 +1,8 @@
+# DopeFlipper
+
+DopeFlipper is a CK42X Flipper Zero market game packaged for the Flipper Application Catalog.
+
+- App id: ck42x_dopewars
+- Version: 0.7.9
+- Category: Games
+- Source: https://github.com/lordbuffcloud/flipper-ck42x-dopeflipper

--- a/applications/Games/ck42x_dopewars/manifest.yml
+++ b/applications/Games/ck42x_dopewars/manifest.yml
@@ -1,0 +1,10 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/lordbuffcloud/flipper-ck42x-dopeflipper.git
+    commit_sha: 0af659197cc8744b465942c26cc299f756fe7076
+short_description: CK42X pocket market game inspired by ck42x.com/dopewars.
+description: "@catalog_description.md"
+changelog: "@catalog_changelog.md"
+screenshots:
+  - screenshots/dopeflipper-title.png


### PR DESCRIPTION
## Summary
- Adds DopeFlipper metadata for the catalog.
- Points the catalog manifest at the public CK42X source repo for version 0.7.9.

## Validation
- Source repo GitHub Action passed for commit 0af659197cc8744b465942c26cc299f756fe7076.
- Local uFBT build passed: Target 7, API 87.1.
- Catalog bundle validation passed with tools/bundle.py.
