### PR TITLE
Add NestBridge app

### DIFF
--- a/applications/GPIO/nest_bridge/manifest.yml
+++ b/applications/GPIO/nest_bridge/manifest.yml
@@ -1,0 +1,18 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Bibfortuna5057/NestBridge-Flipper.git
+    commit_sha: 9d5471b
+ 
+app:
+  id: nest_bridge
+  name: NestBridge
+  author: Bibfortuna5057
+  version: "1.0"
+  short_description: Control a NoLongerEvil Nest thermostat from your Flipper via BLE advertisements
+  description: |
+    Control a NoLongerEvil flashed Nest Gen 1/2 thermostat from your Flipper Zero using BLE advertisement packets. No phone, no pairing, no connection between devices. Set temperature, change mode, and set fan timers from a simple menu.
+  category: GPIO
+  screenshots: []
+  links:
+    source_code: https://github.com/Bibfortuna5057/NestBridge-Flipper

--- a/applications/GPIO/nest_bridge/manifest.yml
+++ b/applications/GPIO/nest_bridge/manifest.yml
@@ -2,17 +2,11 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Bibfortuna5057/NestBridge-Flipper.git
-    commit_sha: 9d5471b
- 
-app:
-  id: nest_bridge
-  name: NestBridge
-  author: Bibfortuna5057
-  version: "1.0"
-  short_description: Control a NoLongerEvil Nest thermostat from your Flipper via BLE advertisements
-  description: |
-    Control a NoLongerEvil flashed Nest Gen 1/2 thermostat from your Flipper Zero using BLE advertisement packets. No phone, no pairing, no connection between devices. Set temperature, change mode, and set fan timers from a simple menu.
-  category: GPIO
-  screenshots: []
-  links:
-    source_code: https://github.com/Bibfortuna5057/NestBridge-Flipper
+    commit_sha: 92be2681ff9fc4924cef16acdc8ee80e646ecf40
+short_description: "Control a NoLongerEvil Nest thermostat from your Flipper Zero via BLE advertisements"
+description: "@README.md"
+changelog: "v1.0 - Initial release"
+screenshots:
+  - "./screenshots/1.png"
+  - "./screenshots/2.png"
+  - "./screenshots/3.png"


### PR DESCRIPTION
# Application Submission

- Control a NoLongerEvil flashed Nest Gen 1/2 thermostat from a Flipper Zero using BLE advertisement packets. Set temperature, change mode, and set fan timers from a simple menu.


# Extra Requirements 

- Requires an ESP32 development board with WiFi and BLE running MicroPython, a Nest Gen 1 or Gen 2 thermostat running NoLongerEvil firmware, and an NLE API key.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

-  FAP UI code and MicroPython script were AI assisted. The BLE advertisement communication approach and overall architecture were developed through iterative testing.

# Reviewer Checklist (Don't fill this out!)

- [ ] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
