### PR TITLE
Add flipnCGM 1.0 — Abbott FreeStyle Libre CGM serial reader (NFC)

### DIFF
--- a/applications/NFC/flipncgm/manifest.yml
+++ b/applications/NFC/flipncgm/manifest.yml
@@ -1,0 +1,10 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/darendarrow/flipnCGM.git
+    commit_sha: a79403a072cee8cd172231e8e7c79b2d053cb14f
+description: "@catalog_description.md"
+changelog: "@CHANGELOG.md"
+screenshots:
+  - screenshots/scanning.png
+  - screenshots/result.png

--- a/applications/NFC/flipncgm/manifest.yml
+++ b/applications/NFC/flipncgm/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/darendarrow/flipnCGM.git
-    commit_sha: a79403a072cee8cd172231e8e7c79b2d053cb14f
+    commit_sha: 4524fb0e6d679e20a185191851921352f2104f83
 description: "@catalog_description.md"
 changelog: "@CHANGELOG.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

- This application reads the serial number of Abbott FreeStyle Libre CGMs (continuous glucose monitor) via NFC.  It reads the ISO 15693 NFC tag and decodes the 8-byte UID to a human-readable serial number.

## How the serial number is decoded

FreeStyle Libre sensors store their serial number inside the NFC tag's 8-byte UID.
flipnCGM reads that UID passively over ISO 15693 — no sensor activation required —
and decodes it to the 9-character serial printed on the sensor packaging.

### UID layout

| Byte(s) | Example | Role |
|---------|---------|------|
| 0 | `E0` | Fixed ISO 15693 tag identifier |
| 1 | `7A` | Abbott Diabetes Care manufacturer code |
| 2–7 | variable | 48 bits encoding the serial number |

Bytes 0 and 1 are checked first to confirm the tag is a genuine Abbott Libre before
decoding is attempted.

### Decode steps

1. **Concatenate bytes 2–7 into a single 48-bit big-endian integer.**
   For example, `C2 1C C6 45 11 7A` → `0xC21CC645117A`.

2. **Extract nine 5-bit groups**, reading from the most significant bits downward.
   (9 × 5 = 45 bits; the three most significant bits are always zero and are discarded.)
   Each group is a value in the range 0–31.

3. **Map each value through a 32-character alphabet:**

   ```
   0123456789ACDEFGHJKLMNPQRTUVWXYZ
   ```

   The letters **B, I, O, and S** are omitted to avoid visual ambiguity on printed labels
   (B≈8, I≈1, O≈0, S≈5).

4. The nine resulting characters are the serial number — e.g. `0R8FDDJ8J` — identical
   to what Abbott prints on the sensor box and applicator.


# Extra Requirements 

- None


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

- All code was generated by Claude with human guidance and testing of the application against known CGMs to validate serial numbers were decoded the same. 

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
