### PR TITLE
fix: sync usb hid autofire source

### DIFF
--- a/applications/USB/usb_hid_autofire/manifest.yml
+++ b/applications/USB/usb_hid_autofire/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/xMasterX/all-the-plugins.git
-    commit_sha: a2004a3539c50ced20f6f24e61ba17c1dd86460b
+    commit_sha: dda1d83a53a2c330440a641ac167b64ce4c448ba
     subdir: apps_source_code/usb_hid_autofire
 description: "@./catalog/docs/Readme.md"
 changelog: "@./catalog/docs/Changelog.md"


### PR DESCRIPTION
## Summary
- update `usb_hid_autofire` to the latest synced `all-the-plugins` source
- picks up the corrected `fap_version` from `application.fam`

## Verification
- confirmed the pinned source has `appid="usb_hid_autofire"` and `fap_version="1.1"`
- ran `python3 tools/bundle.py --nolint applications/USB/usb_hid_autofire/manifest.yml /tmp/usb_hid_autofire_bundle.zip`
- ran `git diff --check`

Fixes #955
