### PR TITLE
Bump Seader to v4.1

### DIFF
--- a/applications/NFC/seader/manifest.yml
+++ b/applications/NFC/seader/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/bettse/seader.git
-    commit_sha: 57064e15066b5f4f7a70c9aa42396ee97ecb585d
+    commit_sha: bf10c834ebf90444c916887ecbb714a1e615600b
 short_description: "Allows for reading credential from HID iClass, iClass SE, Desfire EV1/EV2, and Seos"
 description: |
   Allows for reading credential from HID iClass, iClass SE, MFC SE, Desfire EV1/EV2, and Seos. Credentials can be saved in an agnostic format, or as various Flipper formats (Prox, MFC, iClass, iClass SR), depending on the original type.


### PR DESCRIPTION
# Application Submission

Bump Seader to v4.1. Notable changes since v4.0:
- Multi-tech HF card selection and MFC SE credential reading
- SNMP probe integrated into the SAM API
- CCID / T=1 long-response handling and conformance fixes
- Significant RAM/memory footprint reductions and startup stability improvements
- HF runtime moved behind a plugin boundary with improved lifecycle/SAM cleanup
- Always compute Kd from CSN
- Added host/integration test harness

# Extra Requirements

Requires addon: UART to mini-SIM adapter and HID SAM (unchanged from prior releases).

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/NFC/seader/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).

Portions of the app code (memory/RAM optimizations, ASN.1 footprint reduction, CCID/T=1 refactors, and HF runtime plugin restructuring) were developed with AI assistance and reviewed by the maintainer. The catalog manifest change itself is not AI-generated.

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
