### PR TITLE
[GPIO] Water Sensor reader

### DIFF
--- a/applications/GPIO/water_sensor_reader/manifest.yml
+++ b/applications/GPIO/water_sensor_reader/manifest.yml
@@ -1,0 +1,9 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/MatveyStrelov/flipper-water-sensor.git
+    commit_sha: eb6dfd132ddb5b13cb30cb082d20acf5cd96dbf9
+description: "@readme.md"
+changelog: "@CHANGELOG.md"
+screenshots:
+  - screenshots/0.png


### PR DESCRIPTION
## Water Sensor reader (GPIO)

A simple Flipper Zero app that reads an analog water sensor on GPIO pin **C0** (ADC channel 1) and shows the live raw ADC value, the voltage in mV, and a level progress bar.

### Source
- Repository: https://github.com/MatveyStrelov/flipper-water-sensor
- Commit: `eb6dfd132ddb5b13cb30cb082d20acf5cd96dbf9`
- Category: GPIO
- Version: 1.0 (initial release)

### Hardware requirements
- An analog water/liquid-level sensor whose analog output is wired to pin **C0** and ground on the Flipper Zero.

### How to test
1. Wire the sensor's analog out to C0 and GND.
2. Launch **Water Sensor reader** from the GPIO apps menu.
3. The screen shows RAW (0-4095), voltage in mV, and a level bar that follows the sensor. Touching/wetting the sensor changes the readings in real time.
4. Press Back to exit.

### Checklist
- [x] I own the code and it is published under my repository above.
- [x] `application.fam` has `fap_version`, `fap_category`, `fap_author`, `fap_weburl`, `fap_description`.
- [x] Screenshot captured with qFlipper (512x256, unmodified).
- [x] Validated locally: `python tools/bundle.py applications/GPIO/water_sensor_reader/manifest.yml bundle.zip` builds, lints, and bundles successfully.
