### PR TITLE
Add SubGHz-RAW-Edit app

### DIFF
--- a/applications/Sub-GHz/subghz_raw_edit/manifest.yml
+++ b/applications/Sub-GHz/subghz_raw_edit/manifest.yml
@@ -1,0 +1,38 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Lechnio/SubGHz-RAW-Edit.git
+    commit_sha: e8658d509dca89d951425bf3522314da2c3c4222
+short_description: "A tiny on-device waveform editor for Flipper Zero that trims RAW .sub captures down to just the part you care about."
+description: |
+  A tiny on-device waveform editor for Flipper Zero that trims RAW .sub
+  captures down to just the part you care about. Open a recording, let the
+  app find the actual signal hiding inside a long stretch of silence, slide
+  two markers to the start and end of one clean frame, and save it as a new
+  .sub file.
+
+  **Receive and analysis only.** This app never transmits. It only reads,
+  displays and rewrites files you already have on the SD card.
+
+  ## Controls
+
+  - **Left / Right** - move the active cut marker (hold to move faster)
+  - **Up / Down** - zoom in and out, centered on the active marker
+  - **OK (short press)** - switch the active marker between A and B
+  - **OK (hold)** - save the trimmed file
+  - **Back** - exit
+
+  ## Usage
+
+  1. Launch Sub-GHz RAW Edit from the Apps menu, under Sub-GHz.
+  2. Pick a RAW .sub file from /ext/subghz.
+  3. The view opens centered on the detected frame. Zoom out to see the whole
+     signal, zoom in to see individual pulses.
+  4. Place A at the start of one clean frame, press OK, then place B at the end.
+  5. Hold OK to save. The trimmed copy is written next to the original in
+     /ext/subghz, auto-numbered so saves never overwrite an earlier trim.
+changelog: "@changelog.md"
+screenshots:
+  - ./docs/images/03-zoom-mid.png
+  - ./docs/images/04-zoom-closer.png
+  - ./docs/images/05-waveform.png


### PR DESCRIPTION
# Application Submission

- [ Describe your application here - its features or what has changed since the last version ]

Everything is in the [readme](https://github.com/Lechnio/SubGHz-RAW-Edit/blob/main/README.md).
But shortly it allows to trim raw .sub files to extract specific part of it and save to separate file.
Very useful if you have long RAW .sub files with a lot of noise because you were waiting for a short signal repeat.

The application draws a signal diagram using timing density changes of the signal because the .sub files don't contain any RSSI data. Therefore I've implemented Y axis view based on timing density. The more signal changes during specific time window (more positive/negative edges), the higher density and the higher Y axis on the diagram.

# Extra Requirements 

- [ Describe if your application requires any extra hardware or software ]

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- [ Describe how AI was used in this PR if it was used ]

AI used to generate readme for the project and little bit for density algorithm that groups signal parts on the screen.

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
