### PR TITLE
Add Tutu (flipper_tutu) to Games

### DIFF
--- a/applications/Games/flipper_tutu/manifest.yml
+++ b/applications/Games/flipper_tutu/manifest.yml
@@ -1,0 +1,27 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Endika/flipper-tutu.git
+    commit_sha: b325ad728cf85c7e896b47c9e8bd5bb507b9a56f
+short_description: Sliding car puzzle (Rush Hour) with 100 levels of increasing difficulty.
+description: |
+  Tutu is a sliding car puzzle (Rush Hour) for the Flipper Zero. Slide the other cars out
+  of the way and drive the red car to the exit on the right edge of the board. It ships
+  100 pre-generated, solver-verified levels whose difficulty climbs steadily — from a
+  couple of moves up to around 24 — with the hard ramp kicking in near level 75. Pick a
+  car with OK (it cycles through the cars in spatial order) and slide it along its lane
+  with the D-pad; hold OK to reset a level. Levels unlock in sequence and your progress is
+  saved to the SD card. Fully offline, with no network or accounts, plus a level-select
+  grid and a credits screen.
+author: Endika
+version: 0.1.5
+changelog: |
+  - v0.1.5: Updated catalog screenshots to native device-resolution captures (no gameplay changes).
+  - v0.1.4: New app icon (the puzzle board with the hero car exiting), a clearer exit marker, and layout polish on the menu, credits and in-game HUD.
+  - v0.1.0: Initial release — 100 Rush Hour levels with increasing difficulty, cycle-and-slide controls, a level-select grid with progress saved to the SD card, and a credits screen.
+category: Games
+id: flipper_tutu
+name: Tutu
+screenshots:
+  - assets/game.png
+  - assets/menu.png


### PR DESCRIPTION
# Application Submission

-  Tutu is a sliding car puzzle (Rush Hour) for the Flipper Zero. Drive the red car to the exit on the right edge of the board: cycle through the cars with OK and slide the selected one along its lane with the D-pad (hold OK to reset, Back to leave a level). It ships 100 pre-generated, solver-verified levels with a difficulty curve that climbs from ~2 up to ~24 optimal moves (the hard ramp starts around level 75). Levels unlock sequentially and progress is saved to the SD card. Includes a level-select grid and a credits screen. Fully offline.

Initial submission (v0.1.5). Source: https://github.com/Endika/flipper-tutu


# Extra Requirements 

- None


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- to improve descriptions, code comments, commits text and icon.

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
