### PR TITLE
Add San Morse 1.0

### DIFF
--- a/applications/Tools/san_morse/manifest.yml
+++ b/applications/Tools/san_morse/manifest.yml
@@ -1,0 +1,33 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/sanjorgek/san-morse-flipper.git
+    commit_sha: f7dcf0559060b98044b205f2a965eda38f49d12d
+
+short_description: Morse code trainer with a decision-tree guide and text-to-Morse playback
+
+description: |
+  Learn and write Morse code without memorizing the codes first.
+
+  **Decision tree:** the screen shows the dichotomic Morse tree (E/T,
+  I/A/N/M, ...) and the OK button works as a telegraph key: quick release
+  is a dot, holding is a dash. You always see which node you are on and
+  which character the next symbol would give you. A short pause commits
+  the letter and a longer pause adds a space, with a visible countdown.
+  Numbers and signs live on level 5: the view zooms in to show them.
+
+  **Text to Morse:** type a text and play it back with sound, LED and
+  vibration, highlighting the current character and symbol, with live
+  adjustable speed.
+
+  **Persistent settings:** language (English/Spanish), volume, tone,
+  vibration, LED, WPM speed, dot/dash threshold and commit timings.
+
+changelog: "@./docs/changelog.md"
+
+screenshots:
+  - screenshots/ss0.png
+  - screenshots/ss1.png
+  - screenshots/ss2.png
+  - screenshots/ss3.png
+  - screenshots/ss4.png

--- a/applications/Tools/san_morse/manifest.yml
+++ b/applications/Tools/san_morse/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/sanjorgek/san-morse-flipper.git
-    commit_sha: f7dcf0559060b98044b205f2a965eda38f49d12d
+    commit_sha: cbef9ffab5510ce51d86e87bc0617861cfb28a29
 
 short_description: Morse code trainer with a decision-tree guide and text-to-Morse playback
 
@@ -20,8 +20,9 @@ description: |
   vibration, highlighting the current character and symbol, with live
   adjustable speed.
 
-  **Persistent settings:** language (English/Spanish), volume, tone,
-  vibration, LED, WPM speed, dot/dash threshold and commit timings.
+  **Persistent settings:** language (English by default, Spanish optional),
+  volume, tone, vibration, LED, WPM speed, dot/dash threshold and commit
+  timings.
 
 changelog: "@./docs/changelog.md"
 
@@ -31,3 +32,4 @@ screenshots:
   - screenshots/ss2.png
   - screenshots/ss3.png
   - screenshots/ss4.png
+  - screenshots/ss5.png


### PR DESCRIPTION
# Application Submission

San Morse 1.0 — a Morse code trainer designed for learning while you write, instead of requiring you to know the codes beforehand.

- Interactive Morse **decision tree** on screen; the OK button works as a telegraph key (quick release = dot, hold = dash), with pause-based letter commit and a visible countdown. Numbers and signs live on level 5 of the tree, with automatic zoom.
- **Text to Morse**: type a text and play it back with sound, LED and vibration, highlighting the current character/symbol, with live adjustable speed.
- **English interface by default**, with Spanish available as an option in Settings.
- Persistent settings: language, volume, tone, vibration, LED, WPM speed and key timings.

Source: https://github.com/sanjorgek/san-morse-flipper

# Extra Requirements

None — uses only the built-in speaker, LED, vibration and SD card (settings file).

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

- The app was written with Claude Code under my direction and tested on real hardware (Flipper Zero, official firmware 1.4.3). The code consists of: a Morse lookup table and the dichotomic tree stored as a binary-heap array (`morse.c`); a custom View that renders the tree with windowed zoom and handles OK press/release timing as a telegraph key, with a 50 ms timer for pause-based letter/space commit (`san_morse.c`); a playback worker thread that converts text to dot/dash timings (PARIS standard) and drives speaker/LED/vibration (`player.c`); persistent settings stored as a versioned blob on the SD card (`settings.c`); and a static string table for the UI, English first so it is the default, with Spanish selectable in Settings (`i18n.c`). The manifest was validated with `tools/bundle.py` including the full lint/build step.
- Revision after review (same tooling, my direction): the English strings were moved to index 0 of the string table so the app starts in English and *Language* is the first item in Settings; the settings blob magic was bumped so a `settings.bin` written by the previous build (where index 0 meant Spanish) is discarded instead of preserving the old default. Screenshots were re-captured on hardware with the English UI.
