### PR TITLE
Add FCC ID Lookup app

### DIFF
--- a/applications/Tools/fcc_id_lookup/manifest.yml
+++ b/applications/Tools/fcc_id_lookup/manifest.yml
@@ -1,0 +1,14 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/lrehmann/fcc-id-lookup-flipper.git
+    commit_sha: 03fc63b556baa5c24d9529c0583668691f6b3c4d
+short_description: Offline FCC ID applicant and frequency lookup
+description: "@catalog_description.md"
+changelog: "@changelog.md"
+screenshots:
+  - screenshots/intro-qr.png
+  - screenshots/search-empty.png
+  - screenshots/search-prefix.png
+  - screenshots/detail-summary.png
+  - screenshots/detail-frequencies.png


### PR DESCRIPTION
## Summary

Adds the FCC ID Lookup app manifest to the Tools category.

FCC ID Lookup is an offline FCCID.io-derived applicant and frequency lookup app for Flipper Zero. It supports exact FCC ID lookup and prefix browsing, with result detail pages showing applicant and supported frequency ranges.

## Notes for Review

- Source repository: https://github.com/lrehmann/fcc-id-lookup-flipper
- Source commit: 03fc63b556baa5c24d9529c0583668691f6b3c4d
- The app includes a large direct-read offline database asset, currently about 8.9 MB.
- The app description includes a visible warning that catalog installation and first launch may take longer while Flipper transfers/unpacks the database asset.
- Data attribution is included in the app and source description.

## Validation

- Ran catalog bundle validation:
  python3 tools/bundle.py --nolint applications/Tools/fcc_id_lookup/manifest.yml /tmp/fcc_id_lookup_bundle.zip
- The validator built the app from the referenced source commit and created the bundle successfully.
- Reviewed existing Tools manifests including tone_gen, hex_viewer, and roman_decoder for manifest placement and source-description patterns.

## Checklist

- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I performed self-review
