### PR TITLE
Add Survival Manual app

### DIFF
--- a/applications/Tools/survival_manual/manifest.yml
+++ b/applications/Tools/survival_manual/manifest.yml
@@ -1,0 +1,12 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Radiomanrf/Survival_manual.git
+    commit_sha: 6f957c7d6996af30ee451c4a241693ddb44209f9
+description: "@README.md"
+changelog: "@changelog.md"
+author: "Louis (@Radiomanrf)"
+screenshots:
+  - "screenshots/list.png"
+  - "screenshots/selection.png"
+  - "screenshots/text.png"


### PR DESCRIPTION
# Application Submission
Survival Manual — an offline survival reference reader. It contains 37 chapters
(421 sections) from the libre Survival Manual, which is derived from the public-domain
US Army field manual FM 21-76. Navigation is Pages → Sections → scrollable text. The
chapter text ships as SD-card assets and each section is loaded on demand by byte
offset, so RAM use stays low regardless of chapter size. This is the initial release (v1.0).

# Extra Requirements
None. No additional hardware or software required — the app reads its bundled text
assets from the SD card.

# Author Checklist (Fill this out)
- [x] I've read the contribution guidelines and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have validated the manifest file(s) with `python3 tools/bundle.py --nolint applications/Tools/survival_manual/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):
- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated

AI was used to convert the upstream Survival Manual wiki text into Flipper-readable
asset files. The manual content is the public-domain US Army FM 21-76, via the GPLv3
ligi/SurvivalManual project.

# Reviewer Checklist (Don't fill this out!)
- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code