### PR TITLE
Add Answer Book (Tools) v0.1

### DIFF
--- a/applications/Tools/answer_book/manifest.yml
+++ b/applications/Tools/answer_book/manifest.yml
@@ -1,0 +1,13 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/redbson/The-Book-of-Answers.git
+    commit_sha: 06b07f5042b0345cf4ee97fd1e74a8fa1f7bc040
+short_description: "A book of answers that replies to your question from the Flipper's live radio and sensor state."
+description: "@catalog/description.md"
+changelog: "@changelog.md"
+author: "redbson"
+screenshots:
+  - screenshots/1.png
+  - screenshots/2.png
+  - screenshots/3.png


### PR DESCRIPTION
# Application Submission

**Answer Book** (Tools, v0.1) — turns the Flipper Zero into a "book of answers". You hold a question in mind, press OK to open a page, and the book replies with one short answer.

The answer is not a plain `rand()`: each page open runs a brief, **receive-only** sensing pass (BLE RSSI sampling, SubGHz RSSI/LQI on common regional bands, a short NFC scan, plus device RTC/battery telemetry and the hardware RNG) and folds it into a 32-bit FNV-1a hash that seeds a weighted category choice, the specific answer, and a rarity roll. Because the environment is never identical twice, repeated questions rarely give the same page. The UI stays a quiet book — no signal scanner is shown.

Three screens: Cover (idle), Opening (page-turn animation), and Page (the result, with page number, rarity, answer, and category). Five categories (Forward, Observe, Warning, Explore, Reflection) and three rarities (Normal, Rare, Legendary).

This is the initial release.

# Extra Requirements

None. Runs on a stock Flipper Zero — no extra hardware, GPIO modules, or expansion boards. Uses only the built-in radios and sensors, all in receive/sample mode. **The app never transmits on SubGHz.**

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/Tools/answer_book/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Fully AI generated (explain what all the generated code does in moderate detail).

The application (a single `answer_book.c`, ~800 lines) was AI-generated. It implements: a Furi-based app loop with a ViewPort and GUI; three rendering states (cover, opening animation, result page) drawn with the firmware canvas API and bundled icon assets; an "oracle" engine that performs short, read-only samples via the BLE, SubGHz, and NFC HALs plus RTC/power telemetry and `furi_hal_random_get()`, reduces them to a five-axis vector, and folds everything into an FNV-1a hash used to pick an answer category, a specific answer string, and a rarity; and a logger that appends each result as one JSON line to the app's data directory. All radio use is receive/sample only — the app does not transmit. The catalog submission files (manifest, description, changelog, screenshots) were prepared with AI assistance as well.
