### PR TITLE
Update SubGHz-RAW-Edit to v1.6

### DIFF
--- a/applications/Sub-GHz/subghz_raw_edit/manifest.yml
+++ b/applications/Sub-GHz/subghz_raw_edit/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/Lechnio/SubGHz-RAW-Edit.git
-    commit_sha: 319960bd47a0173f178c1b5ddbf2c5804a723eb9
+    commit_sha: d4e7d3c215c56451a5c60783751b2b267a0403d3
 short_description: "A tiny on-device waveform editor for Flipper Zero that trims RAW .sub captures down to just the part you care about."
 description: |
   A tiny on-device waveform editor for Flipper Zero that trims RAW .sub


### PR DESCRIPTION
# Application Submission

- [ Describe your application here - its features or what has changed since the last version ]

Made some tests on other firmware's and realized that different implementations of `subghz_transmitter_deserialize` use different amount of stack and the limit of this app was set just to 2KB which was on the edge of required minimum.
Which end up with stack overflow while merging recognized signals by using this API.

So the changelog is quite limited (huh):
- Fixed MPU fault stack overflow error on some flipper firmware's. The bottle neck is internal deserializer called when loading recognized signals. The change bumps the application stack from 2KB to 3KB as it seems sufficient value.
Note: If you ever encounter this issue in the future please let me know on GitHub. I don't want to raise this value too high if it's not needed because raising the stack reduces the already very limited heap resources.

(sorry for the release/PR spam but it didn't let me sleep well XD)

# Extra Requirements 

- [ Describe if your application requires any extra hardware or software ]


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- [ Describe how AI was used in this PR if it was used ]

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
