### PR TITLE
Update Access Audit to v1.9

### DIFF
--- a/applications/Tools/access_audit/manifest.yaml
+++ b/applications/Tools/access_audit/manifest.yaml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/matthewkayne/flipper-access-audit.git
-    commit_sha: 966fbe742b5f71c9a0ac7e3d7d18803402d76ba9
+    commit_sha: 5e4356299c4e1780772e7c27d2be0ab561a21cd4
 author: Matthew Kayne
 description: "@docs/catalog-description.md"
 changelog: "@./CHANGELOG.md"


### PR DESCRIPTION
Updates **Access Audit** (Tools) to v1.9.

Pins `commit_sha` to `5e4356299c4e1780772e7c27d2be0ab561a21cd4` (`fap_version` 1.9).

Release: https://github.com/matthewkayne/flipper-access-audit/releases/tag/v1.9.0

Changes since the previously published version: the MIFARE Classic active default-key check now covers 8 well-known public keys, and a default-key finding is surfaced on the result screen.