### PR TITLE
Update Access Audit to v1.10

### DIFF
--- a/applications/Tools/access_audit/manifest.yaml
+++ b/applications/Tools/access_audit/manifest.yaml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/matthewkayne/flipper-access-audit.git
-    commit_sha: 966fbe742b5f71c9a0ac7e3d7d18803402d76ba9
+    commit_sha: aa4aea8a870906f3c8b01cc98b7f111ea63d3105
 author: Matthew Kayne
 description: "@docs/catalog-description.md"
 changelog: "@./CHANGELOG.md"


### PR DESCRIPTION
Updates **Access Audit** (Tools) to v1.10.

Pins `commit_sha` to `aa4aea8a870906f3c8b01cc98b7f111ea63d3105` (`fap_version` 1.10).

Release: https://github.com/matthewkayne/flipper-access-audit/releases/tag/v1.10.0

Change since the previously published version: audit reports now frame the score as a likelihood-of-compromise rating aligned with the OWASP Risk Rating Methodology. Supersedes #1093.