### PR TITLE
feat(Infrared): add Led remote app

### DIFF
--- a/applications/Infrared/led_remote/manifest.yml
+++ b/applications/Infrared/led_remote/manifest.yml
@@ -1,0 +1,15 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/AugustinKrb/flipper-led-remote.git
+    commit_sha: 358584b187a7b60d0d0189a12180f57868751ed8
+short_description: Universal LED strip remote with IR learning mode
+description: "@README.md"
+changelog: "@./changelog.md"
+screenshots:
+  - screenshots/menu.png
+  - screenshots/remote_18_keys_circle.png
+  - screenshots/remote_18_keys_grid.png
+  - screenshots/remote_24_keys_circle.png
+  - screenshots/learn_buttons.png
+  - screenshots/switch_profiles.png

--- a/applications/Infrared/led_remote/manifest.yml
+++ b/applications/Infrared/led_remote/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/AugustinKrb/flipper-led-remote.git
-    commit_sha: 358584b187a7b60d0d0189a12180f57868751ed8
+    commit_sha: 093b2ae3463461c2772abb40771d6d1fb8de6636
 short_description: Universal LED strip remote with IR learning mode
 description: "@README.md"
 changelog: "@./changelog.md"

--- a/applications/Infrared/led_remote/manifest.yml
+++ b/applications/Infrared/led_remote/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/AugustinKrb/flipper-led-remote.git
-    commit_sha: 093b2ae3463461c2772abb40771d6d1fb8de6636
+    commit_sha: 0a17d3be9aa12543b0ad3383138dab7f2fe5136e
 short_description: Universal LED strip remote with IR learning mode
 description: "@README.md"
 changelog: "@./changelog.md"


### PR DESCRIPTION
# Application Submission

- Universal IR remote for RGB LED strips. Learn IR signals from your physical remote, then replay them from the Flipper.
- Supports 18-keys and 24-keys layouts, multiple profiles, Circle/Grid visual styles, and RGB LED feedback.

# Extra Requirements 

- Requires an IR-controlled RGB LED strip with its physical remote (for the learn step).

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

- Concept, UX design, feature decisions, testing, and overall direction by me.
- Code implementation was largely written with AI — IR learning/replay via Flipper's infrared worker, scene/view management, profile persistence with FlipperFormat, custom RGB LED sequences, and portrait-mode button grid UI.

# Reviewer Checklist (Don't fill this out!)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
