### PR TITLE
Add Daikin64 AC Remote app

### DIFF
--- a/applications/Infrared/daikin64_ac_remote/manifest.yml
+++ b/applications/Infrared/daikin64_ac_remote/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/mrcalifornium/flipperzero-daikin64-ac-remote.git
-    commit_sha: 64314c619d9397c2bc5f6bb495fbd0fa62905a0f
+    commit_sha: eb9264cbcc747357d5c2a78518c94eb89a64b075
     subdir: applications_user/daikin64_ac_remote
 short_description: "Daikin64 APGS02-compatible AC remote"
 description: "@catalog/description.md"

--- a/applications/Infrared/daikin64_ac_remote/manifest.yml
+++ b/applications/Infrared/daikin64_ac_remote/manifest.yml
@@ -1,0 +1,13 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/mrcalifornium/flipperzero-daikin64-ac-remote.git
+    commit_sha: da7a671d36f547daad988d334b388d722ba1c5cd
+short_description: "Daikin64 APGS02-compatible AC remote"
+description: "@catalog/description.md"
+changelog: "@changelog.md"
+screenshots:
+  - catalog/screenshots/main.png
+  - catalog/screenshots/functions.png
+  - catalog/screenshots/timer.png
+  - catalog/screenshots/favorites.png

--- a/applications/Infrared/daikin64_ac_remote/manifest.yml
+++ b/applications/Infrared/daikin64_ac_remote/manifest.yml
@@ -2,7 +2,8 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/mrcalifornium/flipperzero-daikin64-ac-remote.git
-    commit_sha: da7a671d36f547daad988d334b388d722ba1c5cd
+    commit_sha: c66fbce7660a5ac3b3163abe21de06d53e42c811
+    subdir: applications_user/daikin64_ac_remote
 short_description: "Daikin64 APGS02-compatible AC remote"
 description: "@catalog/description.md"
 changelog: "@changelog.md"

--- a/applications/Infrared/daikin64_ac_remote/manifest.yml
+++ b/applications/Infrared/daikin64_ac_remote/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/mrcalifornium/flipperzero-daikin64-ac-remote.git
-    commit_sha: c66fbce7660a5ac3b3163abe21de06d53e42c811
+    commit_sha: 64314c619d9397c2bc5f6bb495fbd0fa62905a0f
     subdir: applications_user/daikin64_ac_remote
 short_description: "Daikin64 APGS02-compatible AC remote"
 description: "@catalog/description.md"

--- a/applications/Infrared/daikin64_ac_remote/manifest.yml
+++ b/applications/Infrared/daikin64_ac_remote/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/mrcalifornium/flipperzero-daikin64-ac-remote.git
-    commit_sha: eb9264cbcc747357d5c2a78518c94eb89a64b075
+    commit_sha: e5f0d882efdd4d8cc5f5cde26599dd2288158726
     subdir: applications_user/daikin64_ac_remote
 short_description: "Daikin64 APGS02-compatible AC remote"
 description: "@catalog/description.md"


### PR DESCRIPTION
# Application Submission

Daikin64 APGS02-compatible AC remote for Flipper Zero. It dynamically generates Daikin64 HVAC IR packets for power toggle, mode, temperature, fan speed, swing, turbo, quiet, sleep, timers, and five favorite presets.

# Extra Requirements

Requires a Daikin indoor unit compatible with the Daikin64/APGS02 IR protocol. No extra hardware is required beyond the Flipper Zero IR transmitter.

# Author Checklist

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).

OpenAI Codex assisted with porting and structuring the Flipper app, UI iteration, README/catalog metadata, and Daikin64 protocol implementation. Claude Code assisted with the release audit, lint/format fixes, and protocol test corrections. The protocol behavior is based on IRremoteESP8266's IRDaikin64 implementation plus APGS02 captures and on-device testing with a real Flipper Zero and Daikin APGS02 remote.

# Reviewer Checklist (Don't fill this out!)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality
