### PR TITLE
Add FReD FM (fred_fm) v0.11 catalog manifest.

### DIFF
--- a/applications/GPIO/fred_fm/manifest.yml
+++ b/applications/GPIO/fred_fm/manifest.yml
@@ -9,7 +9,8 @@ description: |
   Full wiring, controls, and hardware notes: see the project README on GitHub.
 changelog: "@changelog.md"
 screenshots:
+  - images/Screenshot-20260504-162131.png
+  - images/Screenshot-20260504-131734.png
   - images/Screenshot-20260504-131512.png
   - images/Screenshot-20260504-131541.png
-  - images/Screenshot-20260504-131734.png
   - images/Screenshot-20260504-145422.png

--- a/applications/GPIO/fred_fm/manifest.yml
+++ b/applications/GPIO/fred_fm/manifest.yml
@@ -2,9 +2,10 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/pchmielewski1/tea5767-pt22xx-fm-radio-with-volume-control
-    commit_sha: 7b8b8267b05e9f890f935b8f51e93d4864dd6737
+    commit_sha: df0a662220dc9095dbb10e65467c2e4caaf81d53
 description: |
   FReD FM is a GPIO app for the FReD FM radio board (TEA5767 tuner, PT2257/PT2259-S volume, RDS decode).
+  **Requires the FReD FM expansion board** (PCB v1.1, Tindie) — not a standalone Flipper FM app.
   Tune FM stations, manage presets, adjust volume, and capture RDS debug data to SD.
   Full wiring, controls, and hardware notes: see the project README on GitHub.
 changelog: "@changelog.md"

--- a/applications/GPIO/fred_fm/manifest.yml
+++ b/applications/GPIO/fred_fm/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/pchmielewski1/tea5767-pt22xx-fm-radio-with-volume-control
-    commit_sha: df0a662220dc9095dbb10e65467c2e4caaf81d53
+    commit_sha: 08a71d93b1957c7db105ae77d7c4924bd3526c61
 description: |
   FReD FM is a GPIO app for the FReD FM radio board (TEA5767 tuner, PT2257/PT2259-S volume, RDS decode).
   **Requires the FReD FM expansion board** (PCB v1.1, Tindie) — not a standalone Flipper FM app.

--- a/applications/GPIO/fred_fm/manifest.yml
+++ b/applications/GPIO/fred_fm/manifest.yml
@@ -1,0 +1,15 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/pchmielewski1/tea5767-pt22xx-fm-radio-with-volume-control
+    commit_sha: 7b8b8267b05e9f890f935b8f51e93d4864dd6737
+description: |
+  FReD FM is a GPIO app for the FReD FM radio board (TEA5767 tuner, PT2257/PT2259-S volume, RDS decode).
+  Tune FM stations, manage presets, adjust volume, and capture RDS debug data to SD.
+  Full wiring, controls, and hardware notes: see the project README on GitHub.
+changelog: "@changelog.md"
+screenshots:
+  - images/Screenshot-20260504-131512.png
+  - images/Screenshot-20260504-131541.png
+  - images/Screenshot-20260504-131734.png
+  - images/Screenshot-20260504-145422.png


### PR DESCRIPTION
# Application Submission

FReD FM (`fred_fm`) — GPIO app for the FReD FM radio board: TEA5767 FM tuner, PT2257/PT2259-S digital volume, RDS decode, station presets, and RDS debug capture to SD.

Initial catalog submission v0.11. Source repo: https://github.com/pchmielewski1/tea5767-pt22xx-fm-radio-with-volume-control (commit `7b8b8267b05e9f890f935b8f51e93d4864dd6737`).

# Extra Requirements

Requires FReD FM hardware (TEA5767 module + PT2257 or PT2259-S volume IC on GPIO/I2C). Wiring and board details are in the source repository README.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/GPIO/fred_fm/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

AI was used during app development and for preparing this catalog manifest. Hardware design, assembly, and on-device testing were done by the author.

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality