### PR TITLE
Update Access Audit to v1.12.0

### DIFF
--- a/applications/Tools/access_audit/manifest.yml
+++ b/applications/Tools/access_audit/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/matthewkayne/flipper-access-audit.git
-    commit_sha: 7d881cb54547dfd0fe1ba4fa01f4c823cb086e13
+    commit_sha: 19081a62737f7ecf183bdb2972e4c6eff5f4c2e6
 author: Matthew Kayne
 description: "@docs/catalog-description.md"
 changelog: "@docs/catalog-changelog.md"


### PR DESCRIPTION
Updates the Access Audit entry (Tools) to v1.12.0. Only commit_sha changed; validated with tools/bundle.py.