### PR TITLE
Morse Flipper - an extensive morse code tool

### DIFF
--- a/applications/Tools/morse_flipper/manifest.yml
+++ b/applications/Tools/morse_flipper/manifest.yml
@@ -1,0 +1,17 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/yo3gnd/morse-flipper
+    commit_sha: 4a3527046de7e690252caa19e59e5a84d76221d0
+description: "@README-MARKET.md"
+changelog: "@CHANGELOG-MARKET.md"
+screenshots:
+  - docs/images/ss1.png
+  - docs/images/ss2.png
+  - docs/images/ss3.png
+  - docs/images/ss4.png
+  - docs/images/ss5.png
+  - docs/images/ss6.png
+  - docs/images/ss7.png
+  - docs/images/ss8.png
+  - docs/images/ss9.png

--- a/applications/Tools/morse_flipper/manifest.yml
+++ b/applications/Tools/morse_flipper/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/yo3gnd/morse-flipper
-    commit_sha: 4a3527046de7e690252caa19e59e5a84d76221d0
+    commit_sha: 4e851faf045d4716198ad5f7dbc600f81216444b
 description: "@README-MARKET.md"
 changelog: "@CHANGELOG-MARKET.md"
 screenshots:

--- a/applications/Tools/morse_flipper/manifest.yml
+++ b/applications/Tools/morse_flipper/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/yo3gnd/morse-flipper
-    commit_sha: 4e851faf045d4716198ad5f7dbc600f81216444b
+    commit_sha: ed57581f95ccf15ac481d489e3911c2555c2a7f3
 description: "@README-MARKET.md"
 changelog: "@CHANGELOG-MARKET.md"
 screenshots:

--- a/applications/Tools/morse_flipper/manifest.yml
+++ b/applications/Tools/morse_flipper/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/yo3gnd/morse-flipper
-    commit_sha: 866620a96e5840d1793e40ea29c69f296fdd4318
+    commit_sha: 9526db7000dcab96d6e8c9ce48185f7a97f963e6
 description: "@README-MARKET.md"
 changelog: "@CHANGELOG-MARKET.md"
 screenshots:

--- a/applications/Tools/morse_flipper/manifest.yml
+++ b/applications/Tools/morse_flipper/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/yo3gnd/morse-flipper
-    commit_sha: ed57581f95ccf15ac481d489e3911c2555c2a7f3
+    commit_sha: 866620a96e5840d1793e40ea29c69f296fdd4318
 description: "@README-MARKET.md"
 changelog: "@CHANGELOG-MARKET.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

Adds Morse Flipper, a Morse Code/CW trainer, keyer, hardware adapter, portable ham radio helper and Flipper-to-Flipper morse code transceiver.

Main features:

- Morse Code listening and sending practice.
- LCWO-style trainer (listening exercises, LCWO is a popular morse training website), straight-key trainer, and five-character TX group drills (these are popular in performance CW circles)
- Free practice using Flipper buttons or actual telegraphic keys on configurable GPIO
- Multiple keyer modes: straight, bug, iambic A/B, plain iambic, ultimatic, and keyahead. Keyers are FSMs which work as a sort of musical instrument, the user has two buttons, and depending when one is pressed, it alters what the FSM generates next, a dot or a line (in morse)
- Ham keyer mode for external radio keying and simple field logging. This generates signals to drive a real HF transceiver with a message generated by the Flipper.
- Sub-GHz Morse TX/RX experimenting bench
- On-device Help section with Morse learning notes, wiring notes, practice guidance, operating examples, and external resources.

# Extra Requirements 

No extra hardware is required for basic use. The app works fine with the Flipper buttons and internal buzzer. For hardware testing, a straight key or paddle can be connected through GPIO. TX validation needs a receiver, such as an SDR, transceiver, or second Flipper. RX validation needs a transmitter; again, a second Flipper is enough.

# Author Checklist

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI Usage Disclosure

- [X] Partially AI assisted.
- [ ] Fully AI generated.

AI assistance was used for cleanup, formatting, release copy, and implementation support on some larger features. The app design, feature choices, RF safety behaviour, hardware testing, and final review were human-directed. The bulk of the code, pre 2026, is hand-rolled; I've tested the more exotic paths extensively after introducing AI in the mix.

The largest AI-assisted feature is `cw_markdown_widget.*`, the small Markdown-like renderer used for Help/About screens. It handles justification, scrolling, bullets, simple inline formatting and custom glyphs so the built-in manual is actually readable on a 128x64 display. Since the app has an extensive help menu, I thought this was warranted to improve the reading experience.

Other AI-assisted areas include GPIO key/paddle probing, the TX group grading/fault feedback code, RF frequency selection and TX gating polish, and tuning of the RF receive/decode path against noise. 

# Dev's notes

While the code readers better after the cleanup, it still has several moving parts and the latest review did show some issues (which were fixed). 

Morse Flipper is larger than a typical single-purpose Flipper app because it groups several related Morse tools into one FAP: trainers, keying, GPIO input, USB output, Ham Keyer logging, Sub-GHz Morse experiments, and a built-in help manual. It began as an older hand-written project, then was brought into public-launch shape in 2026 with LLM assistance. 

The app is split into feature modules under `src/firmware/`. Most files have short ownership/dependency comments. The main review surfaces are:

- `keyer.*`: paddle state, keyer modes, event queues, and timing transitions.
- `morse_flipper_cw_decoder.*`: adaptive dit tracking, mark/space decoding, prosigns, and output buffering.
- `morse_flipper_tx_groups.*`: five-character drill targets, captured edge timings, scoring, and fault selection.
- `morse_flipper_rf.*` / `morse_flipper_radio.*`: VFO validation, region-aware defaults, TX gating, CC1101 tuning, and RX/TX timing capture.
- `morse_flipper_ham_*`: external radio keying, PTT, canned messages, and field logging.
- `cw_markdown_widget.*`: compact Help/About renderer.

The timing constants were not picked at random; they were adjusted against nearly-correct human transmission until plausible Morse decoded, while bad timing still failed. Many might look like magic values, but they were found empirically against real GPIO or RF signals.

The big font is a size tradeoff. It makes straight-key practice readable when the Flipper is sitting beyond the user (user who will currently be focusing on his telegraphic key), but it is also a large chunk of the binary. The font packing is deliberately ugly: the rows fit into 24 bits, and C does not offer a friendly uint24_t, so the macro machinery is doing the usual small embedded crime in exchange for flash space.

# Reviewer Checklist

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've run this application and verified its functionality