### PR TITLE
Bump Metroflip to v2.0

### DIFF
--- a/applications/NFC/metroflip/manifest.yml
+++ b/applications/NFC/metroflip/manifest.yml
@@ -20,11 +20,11 @@ screenshots:
   - 'screenshots/Suica_Store2.png'
   
   
-short_description: 'An implementation of Metrodroid on the Flipper Zero'
+short_description: 'Read public transport cards from around the world'
 sourcecode:
   location:
-    commit_sha: 3548f18ae0dfd41fe592561c31e26a6c29154aa2
+    commit_sha: 97bdbb9af28caf78856ac9333bb2576f1194dd52
     origin: https://github.com/luu176/Metroflip
     subdir:
   type: git
-version: 1.0
+version: 2.0


### PR DESCRIPTION
# Application Submission

This is the v2.0 update (from v1.0). What changed since the last version:

**New UI:**
- Redesigned "card view": a paged, scrollable interface with an animated header
  icon, replacing the old flat text output. Used consistently across every card
  type and the About page.

**Card support / reading:**
- Every parser now displays through the card view, including Calypso
  (Navigo / Opus / Rav-Kav) and T-money, which were converted from the old UI
- Calypso: added support for Navigo paper / anonymous tickets and hardened the
  decoder against short/malformed responses
- Suica: fixed several reading crashes and corrected the Octopus balance display

**Stability & memory:**
- Card view is now built on the main thread to avoid NFC-worker-thread UI races
- Fixed protocol-detection, saved-file loading, and poller-lifecycle bugs
- Plugged memory / handle leaks across parsers and raised the app stack so
  saved-file parsing no longer overflows it
- Fixed the scan LED staying lit after backing out of a read without tapping

Also added the GNU GPLv3 license. 

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
