### PR TITLE
Xiaomi Filter Reset 1.0

### DIFF
--- a/applications/NFC/xiaomi_filter_reset/manifest.yml
+++ b/applications/NFC/xiaomi_filter_reset/manifest.yml
@@ -1,0 +1,13 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/khmm12/flipper-xiaomi-filter-reset.git
+    commit_sha: 38ed9eb7bd39388477ddb9ed1b122d6daa0db898
+short_description: Reset or check the filter-life counter on Xiaomi air purifier NFC filters.
+description: "@catalog/description.md"
+changelog: "@catalog/changelog.md"
+author: "@khmm12"
+screenshots:
+  - catalog/screenshots/screenshot_1.png
+  - catalog/screenshots/screenshot_2.png
+  - catalog/screenshots/screenshot_3.png


### PR DESCRIPTION
# Application Submission

Reset or check the **filter-life counter** on Xiaomi air purifier filters (NTAG213), directly from a Flipper Zero — no filter swap and no smartphone app needed.

- **Reset filter life**: authenticates with a password derived from the tag's own UID, writes `00 00 00 00` to the usage counter (page 8), and reads it back to verify. The appliance then reports 100% again.
- **Check filter life** (read-only): the same authenticated read but never writes — confirms a genuine Xiaomi filter and whether it is fresh or already used. It deliberately shows no percentage: the tag only stores elapsed usage, while the full-scale rating lives in the appliance.

Because authentication uses a UID-derived password, a successful operation is itself proof the tag is a supported Xiaomi filter; foreign tags fail auth and are never modified. The password algorithm is validated against golden vectors read from real tags, and the portable core is host-unit-tested (the same object code ships in the app). Reset was verified end-to-end on real hardware: **Mi Air Purifier 4** and **Mi Air Purifier 4 Pro**.

Source: https://github.com/khmm12/flipper-xiaomi-filter-reset

# Extra Requirements

None. No extra hardware or software required — it uses the Flipper's built-in NFC.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/NFC/xiaomi_filter_reset/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).

Developed with Claude Code (Anthropic) as a pair-programmer: most of the C implementation was AI-generated, while all design decisions, code review, hand-edits, and end-to-end hardware verification (Mi Air Purifier 4 / 4 Pro) are mine. The bundled SHA-1 (`src/core/sha1.*`) is a public-domain implementation (after Steve Reid). The UID→password algorithm and memory map are prior third-party reverse engineering, credited in the README.

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
