### PR TITLE
Added upgrade for pause feature from jxc

### DIFF
--- a/applications/Infrared/xremote/manifest.yml
+++ b/applications/Infrared/xremote/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/leedave/flipper-zero-cross-remote
-    commit_sha: c763004922bbaf712236231acd49fada028dd376
+    commit_sha: f7b43fca81b340390876e9fbd20722627d5ec459
 description: "@./docs/README.md"
 changelog: "@./docs/changelog.md"
 author: "Leedave"


### PR DESCRIPTION
# Application Submission

- Upgrade to pause feature, removing the cap of 9s
- Pause can now be configured with mm:ss
- Pause screen can be exited during pause phase
- Backwards compatible with old files


# Extra Requirements 

- None


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
