### PR TITLE
Add CFS Tag Writer app

### DIFF
--- a/applications/NFC/cfs_tag_writer/manifest.yml
+++ b/applications/NFC/cfs_tag_writer/manifest.yml
@@ -1,0 +1,13 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/pwschattenberg/cfs-tag-writer.git
+    commit_sha: 9c2d7e3382f7e5598126c52e0d1deac7fbcafb9b
+description: "@.catalog/README.md"
+changelog: "@changelog.md"
+screenshots:
+  - .catalog/screenshots/00_main_menu.png
+  - .catalog/screenshots/01_read_result.png
+  - .catalog/screenshots/08_write_confirm.png
+  - .catalog/screenshots/12_saved_browser.png
+  - .catalog/screenshots/26_help_index.png

--- a/applications/NFC/cfs_tag_writer/manifest.yml
+++ b/applications/NFC/cfs_tag_writer/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/pwschattenberg/cfs-tag-writer.git
-    commit_sha: 9c2d7e3382f7e5598126c52e0d1deac7fbcafb9b
+    commit_sha: f0399a8cfd5fc9b59c8aa5e0a7b37d1638759b7c
 description: "@.catalog/README.md"
 changelog: "@changelog.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

**CFS Tag Writer** — an NFC app that reads, writes, clones, and erases Creality CFS filament-spool NFC tags (MIFARE Classic 1K with an AES-128 encrypted payload).

CFS filament spools identify themselves as MIFARE Classic 1K tags that store brand, material, color, weight/length, and serial in an encrypted format. This app decodes those tags and writes them back.

Features:
- **Read** — decode a tag and view brand, material, color, weight, length, serial, and UID, plus a Raw/Details view of the decoded 48-byte payload as ASCII and hex.
- **Write from scratch** — a weight-driven wizard (brand → material → color → weight, where weight sets the encoded length), sourced from a built-in filament catalog.
- **Clone / Edit & Write** — copy a read or saved CFS tag byte-for-byte, or tweak fields first.
- **x2 dual-tag writing** — write both of a spool's paired tags with a swap prompt in between.
- **Saved Tags** — stored as standard Flipper MIFARE Classic .nfc files, browsable and re-writable (including dumps from the stock NFC app).
- **Erase** a CFS tag back to blank.
- **Settings** — default brand, serial mode, editable weight presets, and a crypto/data self-test.

This is the initial submission (v1.0).

# Extra Requirements 

No extra hardware or software required beyond the Flipper Zero itself. Works with genuine Creality CFS spool tags and any writable generic MIFARE Classic 1K tag. Uses the firmware-bundled `mbedtls` library for AES-128, linked via `fap_libs`.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

Claude Code was used as a coding assistant throughout development under my direction and review. It helped scaffold and iterate on the scene-manager UI, the async NFC worker thread, tag field encode/decode, and the AES key-derivation and cipher code around `mbedtls`. I reviewed all code and verified functionality on real hardware.

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
