### PR TITLE
Add BreachMap 1.0

### DIFF
--- a/applications/Tools/breach_map/manifest.yml
+++ b/applications/Tools/breach_map/manifest.yml
@@ -1,0 +1,12 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/Gerijacki/BreachMap.git
+    commit_sha: a3bae3a3ba955ddafb79f0bf661c5af5ba2e01eb
+description: "@docs/catalog-description.md"
+changelog: "@docs/changelog.md"
+screenshots:
+  - screenshots/ss0.png
+  - screenshots/ss1.png
+  - screenshots/ss2.png
+  - screenshots/ss3.png


### PR DESCRIPTION
# Application Submission

**BreachMap** is a physical security reconnaissance notebook for **authorized** physical
security assessments. It is not an attack tool — it does not unlock, clone or transmit
anything. It helps an assessor collect, organize and analyze field observations, entirely
offline, and produce a report at the end.

Features:
- **Engagements** — audit sessions with client/location metadata, saved to the SD card
  (safe file naming, rename handling, and overwrite / unsaved-changes prompts).
- **Assets** — doors, RFID readers, cameras, BLE devices, RF devices and unknown targets,
  each with a type, a 0–100 risk score, notes, a finding **severity** and a **remediation** note.
- **Evidence** — link real capture files via the native file browser and auto-extract
  metadata (frequency/preset from `.sub`, device type/UID from `.nfc`), or quick-import the
  latest capture from the SubGHz/NFC folders.
- **Relationship graph** — directed relations between assets (e.g. `Badge → Reader → Door →
  Camera`) rendered on-device with labels and directional arrows, a floorplan layout mode,
  and highlighting of the riskiest attack path to the highest-value asset.
- **Risk propagation** along access/control edges, plus a per-engagement risk summary dashboard.
- **Reports** — export the engagement as JSON or as a Markdown report with an executive
  summary ranked by finding severity.
- **Optional PIN screen lock** for casual protection of the notes (access gate, not at-rest
  encryption).

Everything runs locally on the device; no companion app, no cloud, and no radios are used.

This is the initial release (v1.0).


# Extra Requirements

None. The app is self-contained, requires no additional hardware or add-ons, and only needs
a microSD card to store engagements and exports under `/ext/apps_data/breach_map/`.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/Tools/breach_map/manifest.yml bundle.zip`


# AI usage disclosure (Fill this out):

- [x] Fully AI generated (explain what all the generated code does in moderate detail).

The C source was written with an AI coding assistant under my direction, then reviewed and
tested by me on real Flipper Zero hardware. What the generated code does:
- **App skeleton** (`breach_map.c`, `breach_map_i.h`): standard Furi app setup — GUI,
  ViewDispatcher, SceneManager, records (Storage/Notifications/Dialogs), and the run loop.
- **Models** (`models/`): plain-old-data structs for Session/Asset/Evidence/Relation kept in
  fixed-size arrays inside a single allocation (no per-record dynamic memory).
- **Modules** (`modules/`): `storage_manager` serializes engagements to `.recon` files using
  the Flipper file format; `asset_manager` does asset/evidence CRUD; `graph_engine` computes
  relationship adjacency, risk propagation and the riskiest attack path; `report_generator`
  writes JSON and Markdown; `capture_meta` parses `.sub`/`.nfc` files for metadata; `settings`
  stores the PIN hash.
- **Scenes/views** (`scenes/`, `views/`): the menus, editors, text input, the native file
  browser call, the PIN lock scene, and a custom Canvas view that draws the relationship graph.

The project also includes host-side unit tests for the pure-logic modules and a CI workflow
(GitHub Actions) that runs those tests plus a uFBT build and clang-format lint on every push.
I validated this manifest locally with `tools/bundle.py` and verified every feature on device.


# Reviewer Checklist (Don't fill this out!)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality