### PR TITLE
Add JAYX (USB PC monitor) v0.3

### DIFF
--- a/applications/USB/jayx/manifest.yml
+++ b/applications/USB/jayx/manifest.yml
@@ -1,0 +1,18 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/contactjayclatty/JAYX.git
+    commit_sha: 45de6eeecf00a788f1e597b6a755b0640e99eb37
+    subdir: apps/jayx
+short_description: Live PC CPU/RAM/GPU stats, FPS, and system info over USB
+description: "@README.md"
+changelog: "@changelog.md"
+screenshots:
+  - screenshots/livestats.png
+  - screenshots/fpscounter.png
+  - screenshots/systeminfo.png
+  - screenshots/MainMenu.png
+  - screenshots/osinfo.png
+  - screenshots/cpuinfo.png
+  - screenshots/Aboutpage.png
+  - screenshots/fpscounterNogame.png


### PR DESCRIPTION
## App
**JAYX** — live PC monitor over USB for Flipper Zero.

- **Category:** USB  
- **App ID:** `jayx`  
- **Version:** 0.3  
- **Source:** https://github.com/contactjayclatty/JAYX  
- **Subdir:** `apps/jayx`  
- **License:** MIT  

## Features
- Live CPU / RAM / GPU / VRAM usage and temperatures
- FPS + game/window name (via RTSS on PC)
- System info cards (OS, CPU, memory, GPU, machine brand)
- Windows companion agent: `pc_agent/monitor.py --usb`

## Important notes for reviewers
1. **Requires a Windows PC agent** (documented in app README / repo SETUP.md). The FAP alone shows a waiting screen until the agent streams data over USB CDC.
2. **Bluetooth option is WIP** and only shows a “still in development” message; real use is **USB only**.
3. Screenshots are from qFlipper and live under `apps/jayx/screenshots/`.

## Setup reference
https://github.com/contactjayclatty/JAYX/blob/main/docs/SETUP.md