### PR TITLE
Add Persian Calendar 1.1

### DIFF
--- a/applications/Tools/persian_calendar/manifest.yml
+++ b/applications/Tools/persian_calendar/manifest.yml
@@ -1,0 +1,22 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/AmirNcode/flipper-persian-calendar.git
+    commit_sha: 880ae20c81afea13f38c398764083ec3f7a34626
+short_description: "Persian (Jalali) calendar with date converter and weekday display"
+description: |
+  Shows today's date in both the Persian (Jalali) and Gregorian calendars,
+  with the day of the week in Persian transliteration and English.
+
+  Features:
+
+  - Convert dates: Gregorian to Persian and Persian to Gregorian
+  - Set today's date (writes to the Flipper RTC)
+  - Optional Shahanshahi (Imperial) year display in Settings
+  - Conversion verified against every day from 1800 to 2200
+changelog: "@docs/changelog.md"
+screenshots:
+  - screenshots/ss0.png
+  - screenshots/ss1.png
+  - screenshots/ss2.png
+  - screenshots/ss3.png


### PR DESCRIPTION
# Application Submission

Persian (Jalali) calendar app. Shows today's date in both the Persian and Gregorian calendars with the day of the week in Persian transliteration and English. Converts dates between the two calendars, can set the device date (RTC), and offers an optional Shahanshahi (Imperial) year display in Settings.

# Extra Requirements

No extra hardware or software required.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/Tools/persian_calendar/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

- The app was generated with Claude Code (Claude Fable 5) under my direction. `jalali.c` implements the arithmetic 33-year-cycle (jdf) Jalali<->Gregorian conversion, leap-year and month-length helpers, and Sakamoto's weekday algorithm; it was verified by an exhaustive host-side test walking every day from 1800 to 2200 (146,462 days) in both directions plus known anchor dates. `persian_calendar.c` is a single-viewport GUI app with four screens (today view, menu, date editor, conversion result) plus a settings screen; settings persist via `saved_struct` in the app data folder. I have built, installed, and tested the app on my own Flipper Zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
