### PR TITLE
FM Radio 2.2

### DIFF
--- a/applications/GPIO/fm_radio/manifest.yml
+++ b/applications/GPIO/fm_radio/manifest.yml
@@ -11,7 +11,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/coolshrimp/flipperzero-fm-radio.git
-    commit_sha: 192daea9b595a73e0a8540ced4429ce38ec45cb1
+    commit_sha: f54692a8847ae7de5a4655262a14be71b05c625f
 
 name: FM Radio
 id: fm_radio
@@ -29,6 +29,8 @@ changelog: "@.catalog/CHANGELOG.md"
 screenshots:
   - screenshots/Screenshot1.png
   - screenshots/Screenshot2.png
+  - screenshots/Screenshot3.png
+  - screenshots/Screenshot4.png
 
 targets:
   - f7

--- a/applications/GPIO/fm_radio/manifest.yml
+++ b/applications/GPIO/fm_radio/manifest.yml
@@ -1,0 +1,34 @@
+# Flipper Application Catalog manifest for FM Radio
+#
+# To submit: fork https://github.com/flipperdevices/flipper-application-catalog
+# and add this file as: applications/GPIO/fm_radio/manifest.yml
+# then open a Pull Request.
+#
+# When releasing a new version: update `commit_sha` to the new tagged commit
+# and bump `version` (must match fap_version in application.fam).
+
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/coolshrimp/flipperzero-fm-radio.git
+    commit_sha: 192daea9b595a73e0a8540ced4429ce38ec45cb1
+
+name: FM Radio
+id: fm_radio
+category: GPIO
+version: "2.2"
+author: Coolshrimp
+
+icon: radio.png
+
+short_description: FM radio for TEA5767 and Si4703 tuner boards with auto-detection and SD card station presets.
+
+description: "@.catalog/README.md"
+changelog: "@.catalog/CHANGELOG.md"
+
+screenshots:
+  - screenshots/Screenshot1.png
+  - screenshots/Screenshot2.png
+
+targets:
+  - f7

--- a/applications/GPIO/fm_radio/manifest.yml
+++ b/applications/GPIO/fm_radio/manifest.yml
@@ -1,12 +1,3 @@
-# Flipper Application Catalog manifest for FM Radio
-#
-# To submit: fork https://github.com/flipperdevices/flipper-application-catalog
-# and add this file as: applications/GPIO/fm_radio/manifest.yml
-# then open a Pull Request.
-#
-# When releasing a new version: update `commit_sha` to the new tagged commit
-# and bump `version` (must match fap_version in application.fam).
-
 sourcecode:
   type: git
   location:
@@ -18,19 +9,12 @@ id: fm_radio
 category: GPIO
 version: "2.2"
 author: Coolshrimp
-
-icon: radio.png
-
 short_description: FM radio for TEA5767 and Si4703 tuner boards with auto-detection and SD card station presets.
-
 description: "@.catalog/README.md"
 changelog: "@.catalog/CHANGELOG.md"
-
 screenshots:
   - screenshots/Screenshot1.png
   - screenshots/Screenshot2.png
   - screenshots/Screenshot3.png
   - screenshots/Screenshot4.png
 
-targets:
-  - f7


### PR DESCRIPTION
# Application Submission

FM Radio v2.2 — turns the Flipper Zero into an FM broadcast radio by controlling an external TEA5767 or Si4703 tuner board over I2C.

Features:

- Supports both TEA5767 and Si4703 tuner boards, auto-detected at startup (or force a chip in Settings)
- Station presets loaded from editable .txt files on the SD card, organized by region, with an in-app file viewer
- Seek up/down with adjustable seek strength, plus fine tuning in 0.1 MHz steps
- Volume control on Si4703 (Low / Med / High / Mute) with instant-mute on long OK
- Audio mode: Stereo, Mono (Left), or Mono (Right)
- Start Volume and Resume Station settings; last station and volume persist across runs
- Settings saved automatically to SD card

Source repository: https://github.com/coolshrimp/flipperzero-fm-radio

# Extra Requirements

- Requires an external FM tuner board (TEA5767 or Si4703) wired to the I2C pins: VCC to 3V3 (pin 9), GND to GND (pin 18), SCL to C0 (pin 16), SDA to C1 (pin 15). The Si4703 additionally requires RST to A4 (pin 4) and SEN tied to 3.3V.
- Headphones or a speaker connected to the tuner board's audio output.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- AI assistance was used for portions of the app code (Si4703 driver integration, chip auto-detection, and settings/station-list persistence) and for preparing and validating this catalog manifest. The app tunes TEA5767/Si4703 FM radio chips over I2C and manages station preset files on the SD card.


# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
