### PR TITLE
Add Android KB Bridge (android_keyboard_bridge) 0.5.2

### DIFF
--- a/applications/Bluetooth/android_keyboard_bridge/README.md
+++ b/applications/Bluetooth/android_keyboard_bridge/README.md
@@ -1,0 +1,3 @@
+## Status
+
+[![android_keyboard_bridge](https://catalog.flipperzero.one/application/android_keyboard_bridge/widget)](https://catalog.flipperzero.one/application/android_keyboard_bridge/page)

--- a/applications/Bluetooth/android_keyboard_bridge/manifest.yml
+++ b/applications/Bluetooth/android_keyboard_bridge/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/andybeg/AndroidFlipperZeroKBD.git
-    commit_sha: e877eacabe530fb5fddb6999c64e68c68394b1b5
+    commit_sha: 273b30be5fec3bf5608f4e8f59591d7cdcbb3fde
     subdir: flipper/android_keyboard_bridge
 description: "@README.md"
 changelog: "@changelog.md"

--- a/applications/Bluetooth/android_keyboard_bridge/manifest.yml
+++ b/applications/Bluetooth/android_keyboard_bridge/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/andybeg/AndroidFlipperZeroKBD.git
-    commit_sha: 75374559d9df9a9039eb7d21b785fa9ff23d9e90
+    commit_sha: e877eacabe530fb5fddb6999c64e68c68394b1b5
     subdir: flipper/android_keyboard_bridge
 description: "@README.md"
 changelog: "@changelog.md"

--- a/applications/Bluetooth/android_keyboard_bridge/manifest.yml
+++ b/applications/Bluetooth/android_keyboard_bridge/manifest.yml
@@ -1,0 +1,11 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/andybeg/AndroidFlipperZeroKBD.git
+    commit_sha: 48c08205751fb603602dd972c141aea2351ae53c
+    subdir: flipper/android_keyboard_bridge
+description: "@README.md"
+changelog: "@changelog.md"
+screenshots:
+  - screenshots/screenshot_1.png
+  - screenshots/screenshot_2.png

--- a/applications/Bluetooth/android_keyboard_bridge/manifest.yml
+++ b/applications/Bluetooth/android_keyboard_bridge/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/andybeg/AndroidFlipperZeroKBD.git
-    commit_sha: 273b30be5fec3bf5608f4e8f59591d7cdcbb3fde
+    commit_sha: b87cb96543072c4765b2322f98c9aff663eb7a6c
     subdir: flipper/android_keyboard_bridge
 description: "@README.md"
 changelog: "@changelog.md"

--- a/applications/Bluetooth/android_keyboard_bridge/manifest.yml
+++ b/applications/Bluetooth/android_keyboard_bridge/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/andybeg/AndroidFlipperZeroKBD.git
-    commit_sha: b87cb96543072c4765b2322f98c9aff663eb7a6c
+    commit_sha: 2489d0db6cb590f83cd60280995ebd2e3b14f090
     subdir: flipper/android_keyboard_bridge
 description: "@README.md"
 changelog: "@changelog.md"

--- a/applications/Bluetooth/android_keyboard_bridge/manifest.yml
+++ b/applications/Bluetooth/android_keyboard_bridge/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/andybeg/AndroidFlipperZeroKBD.git
-    commit_sha: e9668a5b6695eacf15ed81396da032c9546fc239
+    commit_sha: cfb3835a6ec00abd4b45a4b9be5e836ac7164e72
     subdir: flipper/android_keyboard_bridge
 description: "@README.md"
 changelog: "@changelog.md"

--- a/applications/Bluetooth/android_keyboard_bridge/manifest.yml
+++ b/applications/Bluetooth/android_keyboard_bridge/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/andybeg/AndroidFlipperZeroKBD.git
-    commit_sha: cfb3835a6ec00abd4b45a4b9be5e836ac7164e72
+    commit_sha: 75374559d9df9a9039eb7d21b785fa9ff23d9e90
     subdir: flipper/android_keyboard_bridge
 description: "@README.md"
 changelog: "@changelog.md"

--- a/applications/Bluetooth/android_keyboard_bridge/manifest.yml
+++ b/applications/Bluetooth/android_keyboard_bridge/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/andybeg/AndroidFlipperZeroKBD.git
-    commit_sha: 48c08205751fb603602dd972c141aea2351ae53c
+    commit_sha: e9668a5b6695eacf15ed81396da032c9546fc239
     subdir: flipper/android_keyboard_bridge
 description: "@README.md"
 changelog: "@changelog.md"


### PR DESCRIPTION
# Application Submission

**Android KB Bridge** (Bluetooth, v0.5) — companion Android phone keyboard/touchpad over BLE Serial into Flipper, which injects USB HID keyboard and mouse events into a host PC.

Features:
- BLE Serial RX with Flipper Serial profile reclaim (so frames go to the FAP, not system RPC)
- Protocol parser (FB 4B frames) for key down/up and mouse move/button/scroll
- USB HID bridge with press/release gap so hosts see taps reliably
- Status UI (USB / phone / frame counters); **Back** exits, **Up** toggles forced backlight
- Exit is Back-only (USB unplug does not close the app); teardown stays fast when the cable is already gone
- Optional on-device screenshots (compiled out for catalog builds)

Source commit: `b87cb96`  
Release (APK + FAP): https://github.com/andybeg/AndroidFlipperZeroKBD/releases/tag/v0.5.1

# Extra Requirements

- Companion Android APK: https://github.com/andybeg/AndroidFlipperZeroKBD/releases/download/v0.5.1/FlipperZeroKbd-0.5.1.apk
- USB data cable Flipper ↔ PC
- Phone paired with Flipper in system Bluetooth settings
- No extra Flipper GPIO / expansion hardware

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/Bluetooth/android_keyboard_bridge/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

The Flipper FAP and companion Android app were **fully AI-generated** (Cursor agent), then reviewed and hardware-tested by the maintainer.

**Flipper FAP (`flipper/android_keyboard_bridge/`, C):**
- `android_keyboard_bridge.c` — app alloc/free, ViewPort status UI, input pubsub (Back/Up), BLE Serial profile start/stop, RX reclaim after BT connect, deferred Serial buffer notify (avoids deadlock), main loop that dequeues HID commands and applies them with a short key gap; Back-only exit; drains HID queue while USB is down
- `protocol.c` — stream resync on FB 4B magic, parse key/mouse frames into AkbHidCmd, enqueue to message queue
- `usb_hid_bridge.c` — switch Flipper USB to HID, key/mouse press-release/move/scroll, restore previous USB config on exit, panic release only while host is connected
- `screenshot.c` — optional triple-Down PBM capture (disabled in catalog builds via AKB_SCREENSHOT)
- Catalog packaging: application.fam, icon.png, README/changelog (catalog-safe markdown), 512×256 screenshots

**Android companion (`android/`):** BLE Serial client + Direct Bluetooth HID client, on-screen multi-layout keyboard, touchpad, settings, routed through BridgeSession / InputSink.

Catalog manifest.yml and this PR text were also prepared with AI.

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality