### PR TITLE
flipper_share_ir: v1.5 (fork of flipper_share, but with IR transport)

### DIFF
--- a/applications/Infrared/flipper_share_ir/manifest.yml
+++ b/applications/Infrared/flipper_share_ir/manifest.yml
@@ -1,0 +1,24 @@
+# PR this file to: https://github.com/flipperdevices/flipper-application-catalog/
+# applications/Infrared/flipper_share_ir/manifest.yml
+
+# Check:
+# python3 -m venv venv
+# pip install -r tools/requirements.txt
+# python3 tools/bundle.py --nolint applications/Infrared/flipper_share_ir/manifest.yml bundle.zip
+
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/lomalkin/flipper-zero-apps.git
+    commit_sha: 8997ab3c95e3818f602fd9dcb39688917d2e062d
+    subdir: flipper_share_ir
+description: "@README_catalog.md"
+changelog: "@CHANGELOG.md"
+screenshots:
+  - screenshots/1.png
+  - screenshots/2.png
+  - screenshots/3.png
+  - screenshots/4.png
+  - screenshots/5.png
+  - screenshots/6.png
+  - screenshots/7.png


### PR DESCRIPTION
# Application Submission

- **Flipper Share IR** transfers any file directly from one Flipper Zero to another over the **Infrared** channel — using only the onboard IR LED (transmitter) and the TSOP demodulating receiver. No extra hardware, cables, phones, computers, internet or radio is needed.
- This is a fork of my previous app [flipper_share](https://lab.flipper.net/apps/flipper_share), but with IR as a transport layer instead of Sub-GHz.


# Extra Requirements 

- You actually need two Flippers to check the app.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- helps me to manage raw IR low-level stuff during change transport from Sub-GHz

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
