### PR TITLE
Add [ESP32] Hotspot Arcade

### DIFF
--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -1,0 +1,15 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/tarikbc/hotspot-arcade.git
+    commit_sha: 62aa6d0585787d2a18259d8b243ce75c6347476c
+    subdir: flipper/hotspot-arcade
+id: hotspot_arcade
+category: GPIO
+short_description: Offline multiplayer party games on the ESP32-S2 WiFi board; friends join your WiFi and play in their phone browser.
+description: "@catalog/DESCRIPTION.md"
+changelog: "@catalog/changelog.md"
+screenshots:
+  - catalog/screenshots/menu.png
+  - catalog/screenshots/dashboard.png
+  - catalog/screenshots/gameselect.png

--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: 62aa6d0585787d2a18259d8b243ce75c6347476c
+    commit_sha: f0f8f2f573c93df986bb5463af56549a08f935c8
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO


### PR DESCRIPTION
# Application Submission

Hotspot Arcade turns a Flipper Zero paired with the official ESP32-S2 WiFi dev board into an **offline multiplayer arcade**. The Flipper hosts an open WiFi network; nearby phones join it and a captive page hands them into a game in their browser over the local network — no internet and no app install, built for dead zones (buses, planes, campsites).

Ten games, all phone-driven: Trivia, Would You Rather, Word Scramble, Reaction Duel, Connect Four, Tic-Tac-Toe, Dots & Boxes, Reversi/Othello, Drawing & guessing, and real-time Pong. Players pick an emoji avatar and can send emoji reactions that float up on everyone's screen. The Flipper shows the lobby and live scoreboard and selects the active game.

Source: https://github.com/tarikbc/hotspot-arcade

# Extra Requirements

Requires the **official Flipper WiFi Dev Board (ESP32-S2)** on the GPIO header.

**The app is self-contained — no SD card setup is needed to review it.** The ESP firmware, the phone web client, and the trivia packs all ship inside the fap via `fap_file_assets` and are extracted to `/ext/apps_assets/hotspot_arcade/` on first launch (note: that first launch spends a few seconds unpacking ~850 KB, which the system loader shows as an hourglass).

To try it: open the app, use **Install Firmware** to flash the board over the GPIO UART (hold BOOT, tap RESET, release BOOT; it verifies with MD5, then asks for a RESET tap to boot the new firmware), then **Start Session** and join the WiFi from a phone at `192.168.4.1`.

Users can optionally override the bundled content from `/ext/apps_data/hotspot_arcade/` (own trivia packs or a custom web bundle), but nothing there is required.

The app captures no credentials and serves only the bundled game. Running an open AP may be restricted in some places (e.g. aircraft); the description notes this.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

The implementation was written with Claude Code under my direction: I set the design, made the product decisions, and validated every feature on real hardware. AI-assisted parts span all three components — the ESP32-S2 firmware (open SoftAP + captive DNS + async web server + a WebSocket game referee that runs the ten games' rules and broadcasts state), the Flipper C app (a framed UART transport, the lobby/dashboard/scoreboard scenes, and an on-device ESP flasher built on Espressif's esp-serial-flasher), and the vanilla-JS phone client (the WebSocket client, screen router, and per-game views). The vendored esp-serial-flasher library (Apache-2.0) is third-party, not generated.

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
