### PR TITLE
Add MP3 Player (mp3_player) 3.4

### DIFF
--- a/applications/Media/mp3_player/manifest.yml
+++ b/applications/Media/mp3_player/manifest.yml
@@ -1,0 +1,37 @@
+# Flipper Application Catalog manifest for MP3 Player
+#
+# To submit: fork https://github.com/flipperdevices/flipper-application-catalog
+# and add this file as: applications/Media/mp3_player/manifest.yml
+# then open a Pull Request.
+#
+# When releasing a new version: update `commit_sha` to the new tagged commit
+# and bump `version` (must match fap_version in application.fam).
+
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/coolshrimp/flipperzero-mp3-player.git
+    commit_sha: 8132ac374dddb731378ebae48bbb14da27b20b4c
+
+name: MP3 Player
+id: mp3_player
+category: Media
+version: "3.4"
+author: Coolshrimp
+
+icon: music_icon.png
+
+short_description: Play any MP3 from the SD card through the internal speaker, a MAX98357A amplifier, or a filtered PAM8403 board.
+
+description: "@.catalog/README.md"
+changelog: "@.catalog/CHANGELOG.md"
+
+screenshots:
+  - screenshots/MainMenu.png
+  - screenshots/SongsList.png
+  - screenshots/NowPlaying.png
+  - screenshots/Settings.png
+  - screenshots/About.png
+
+targets:
+  - f7

--- a/applications/Media/mp3_player/manifest.yml
+++ b/applications/Media/mp3_player/manifest.yml
@@ -1,37 +1,15 @@
-# Flipper Application Catalog manifest for MP3 Player
-#
-# To submit: fork https://github.com/flipperdevices/flipper-application-catalog
-# and add this file as: applications/Media/mp3_player/manifest.yml
-# then open a Pull Request.
-#
-# When releasing a new version: update `commit_sha` to the new tagged commit
-# and bump `version` (must match fap_version in application.fam).
-
 sourcecode:
   type: git
   location:
     origin: https://github.com/coolshrimp/flipperzero-mp3-player.git
     commit_sha: 8132ac374dddb731378ebae48bbb14da27b20b4c
-
-name: MP3 Player
-id: mp3_player
-category: Media
-version: "3.4"
-author: Coolshrimp
-
-icon: music_icon.png
-
-short_description: Play any MP3 from the SD card through the internal speaker, a MAX98357A amplifier, or a filtered PAM8403 board.
-
+author: "Coolshrimp"
+short_description: "Play any MP3 from the SD card through the internal speaker, a MAX98357A amplifier, or a filtered PAM8403 board."
 description: "@.catalog/README.md"
 changelog: "@.catalog/CHANGELOG.md"
-
 screenshots:
   - screenshots/MainMenu.png
   - screenshots/SongsList.png
   - screenshots/NowPlaying.png
   - screenshots/Settings.png
   - screenshots/About.png
-
-targets:
-  - f7


### PR DESCRIPTION
# Application Submission

MP3 Player is a real MP3 player FAP for the Flipper Zero. It plays ordinary `.mp3` files straight from the microSD card with no desktop conversion step, using a vendored [minimp3](https://github.com/lieff/minimp3) decoder (CC0-1.0).

This is a new application submission (first version in the catalog).

Features:

- Plays any MPEG-1/2/2.5 Layer III bitrate from 8 to 320 kbps, CBR and VBR, including mixed-bitrate files. Sample rates from 8 kHz to 48 kHz are resampled automatically for the selected output.
- Three selectable outputs: **Internal** (built-in sounder, 10-bit PWM carrier at 15.625 kHz), **MAX98357A** (I2S at 16 kHz), and **PAM8403** (500 kHz pulse-density stream on pin 3/PA6 through an external RC filter). Only one runs at a time. Software volume scaling applies to all three.
- Scrollable About screen listing the full MAX98357A and PAM8403 pinout, one pin per line.
- Main menu, song list, Now Playing screen with progress bar and battery gauge, settings, and an About/pinout screen.
- Now Playing controls: Up/Down volume, short Left/Right to change track, hold Left/Right to seek in five-second steps, OK to play/pause, Back to return.
- Configurable music folder via `/ext/apps_data/mp3_player/music_path.txt` (defaults to `/ext/music`, invalid paths fall back safely).
- Volume, repeat mode and output selection persist between launches.

ID3v2 tags and embedded album art are skipped without loading artwork into RAM. The decoder uses an 8 KB compressed-data window and a 24 KB thread stack, and the library scan is bounded (5 seconds, 1024 entries, 100 songs) to stay within RAM limits on the STM32WB55.

# Extra Requirements

No extra hardware is required — the app runs on a stock Flipper Zero using the internal sounder.

The internal sounder is a piezo buzzer, so internal playback is buzzy and quiet by nature; this is documented prominently in the app description. For much better audio quality and loudness, an external amplifier can optionally be connected — either a **MAX98357A I2S module** or a **PAM8403 board** driven through a small RC filter. Full wiring is documented in the app README and on the in-app About screen.

MAX98357A:

- BCLK to pin 5 (PB3)
- DIN to pin 2 (PA7)
- LRC/LRCLK to pin 4 (PA4)
- VIN to pin 1 (+5 V)
- GND to any GND pin

PAM8403 (pin 3/PA6 carries a 500 kHz pulse-density stream that must pass through an RC low-pass filter before reaching the board's L/R inputs, each via its own 1 kΩ resistor; 5 V from pin 1, ground common):

- pin 3 (PA6) → RC filter → PAM8403 L and R inputs
- VIN to pin 1 (+5 V)
- GND to any GND pin

On battery power the app enables the 5 V OTG rail during external playback and disables it afterward only if the app enabled it.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

AI assistance was used to clean up and refactor the application source, and to write the documentation and catalog metadata in this submission — the README, `.catalog/README.md`, `.catalog/CHANGELOG.md`, and this `manifest.yml`. The application design and functionality are my own. All of it has been reviewed by me, built with uFBT, and tested on real hardware. The vendored `minimp3.h` is unmodified upstream code under CC0-1.0.


# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality

