### PR TITLE
aprstx bump to 1.3.24

### DIFF
--- a/applications/Sub-GHz/aprstx/manifest.yml
+++ b/applications/Sub-GHz/aprstx/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/yo3gnd/flipper-zero-aprs-tx
-    commit_sha: 52b3821ae7f0f8efb69cea2387832ad9ce4145fe
+    commit_sha: c012ff09123320b598803ac1c3e1387b5c1b31aa
 description: "@README-MARKET.md"
 changelog: "@CHANGELOG-MARKET.md"
 screenshots:

--- a/applications/Sub-GHz/aprstx/manifest.yml
+++ b/applications/Sub-GHz/aprstx/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/yo3gnd/flipper-zero-aprs-tx
-    commit_sha: 1558ee46619b20d97f937a32849ac887c9e192eb
+    commit_sha: 52b3821ae7f0f8efb69cea2387832ad9ce4145fe
 description: "@README-MARKET.md"
 changelog: "@CHANGELOG-MARKET.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

Updates to the APRS transmitter:

- Moved the old `/ext/ham` data into `apps_data`, as requested in #1113.
- Added 9600 baud support.
- Added support for an external CC1101 module.
- Updated a few scenes, including the VFO picker from the other app, with its region validation brought along so it does not do anything too silly.

# Extra Requirements

External CC1101 support is now available, but remains optional. The internal radio path still works without extra hardware.

# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [X] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

One scene, the GPS input scene, was generated completely with AI assistance. External radio support was AI assisted, then manually patched and debugged on hardware. The 9600 baud work is an external contribution and appears to be hand-rolled.

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality