### PR TITLE
Add Ear Trainer 1.1

### DIFF
--- a/applications/Media/ear_trainer/manifest.yml
+++ b/applications/Media/ear_trainer/manifest.yml
@@ -1,0 +1,16 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/barismert98/flipper-ear-trainer.git
+    commit_sha: 151698fcd83d2d2576b8993e62a033bc8556b81c
+short_description: Learn to recognise musical intervals by ear
+description: "@README.md"
+changelog: "@changelog.md"
+screenshots:
+  - screenshots/ss0.png
+  - screenshots/ss1.png
+  - screenshots/ss2.png
+  - screenshots/ss3.png
+  - screenshots/ss4.png
+  - screenshots/ss5.png
+  - screenshots/ss6.png

--- a/applications/Media/ear_trainer/manifest.yml
+++ b/applications/Media/ear_trainer/manifest.yml
@@ -2,15 +2,14 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/barismert98/flipper-ear-trainer.git
-    commit_sha: 151698fcd83d2d2576b8993e62a033bc8556b81c
-short_description: Learn to recognise musical intervals by ear
+    commit_sha: fdfd0d6ed6114366f501efb8de2025a5cc35f18f
+short_description: Learn intervals, chords and scales by ear
 description: "@README.md"
 changelog: "@changelog.md"
 screenshots:
-  - screenshots/ss0.png
-  - screenshots/ss1.png
-  - screenshots/ss2.png
-  - screenshots/ss3.png
-  - screenshots/ss4.png
-  - screenshots/ss5.png
-  - screenshots/ss6.png
+  - screenshots/menu.png
+  - screenshots/scale_teach.png
+  - screenshots/chord_quiz.png
+  - screenshots/chord_feedback.png
+  - screenshots/chord_levels.png
+  - screenshots/progress.png


### PR DESCRIPTION
# Application Submission

Ear Trainer — learn to recognise musical intervals by ear. You hear two notes and name the gap between them. 13 progressive levels ordered widest-first (unison and octave before the tritone and minor 2nd), across Ascending, Descending and Mixed modes, each with its own saved progress. Every new interval gets a teaching screen with its name, size in semitones and a tune that opens with it, and there is an interval reference screen that plays any of the thirteen on demand. Also has mix/review levels with limited lives, hints that strike out wrong answers, stars per level, streaks and lifetime accuracy stats.

App source: https://github.com/barismert98/flipper-ear-trainer

# Extra Requirements 

None — uses only the built-in speaker, vibro motor and LED.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

The app was written with an AI coding assistant under my direction, and it was exercised on real hardware before submission (built against release SDK 1.4.3, API 87.1). What the code does: a SceneManager on top of ViewDispatcher, with scenes for menu, level select, teach, quiz, results, progress, interval reference, settings and about, generated from a single x-macro list so the scene id enum and the three handler tables cannot drift apart. A custom Canvas view renders the quiz — the answer grid of interval short names, the selection highlight, hint strike-throughs, and the feedback screen; the scene owns all quiz state and pushes a snapshot into the view, so the view stays pure rendering. Tone playback runs on a dedicated worker thread with a message queue, acquiring the speaker per message and releasing it when idle so system sounds are not starved, and an abort flag lets a replay cut off whatever is already sounding. Note frequencies are a fixed-point table covering C4 to C6 rather than computing powers at runtime; I verified the table against equal temperament and every note is within 0.1 cents. The interval table, mnemonics and level curriculum are const tables in flash. Quiz generation guarantees repetitions of newly introduced intervals, tops up with review drawn from everything learned so far, then shuffles; the root note is randomised per question by default so it trains relative pitch rather than two memorised pitches. Progress and settings are saved to the SD card as small versioned binary files with magic and version checks plus range validation, so a corrupt file resets to defaults instead of crashing.


# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
