### PR TITLE
Update Hotspot Arcade to 1.1

### DIFF
--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: f0f8f2f573c93df986bb5463af56549a08f935c8
+    commit_sha: 70918258e7ab61bb08e597a2014a8a789e6364a7
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO

--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: 624234d8a30cb2661a2e3d7fb52f841f589a867e
+    commit_sha: a3f03817de1b49b2d970bb4e1cea844c7dd7576a
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO

--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: 70918258e7ab61bb08e597a2014a8a789e6364a7
+    commit_sha: e83d9a4f3dec5217097533aa99b3a3b13bc37d36
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO

--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: e83d9a4f3dec5217097533aa99b3a3b13bc37d36
+    commit_sha: 7ba47286b415dd0d681400492c84e7441cd2d3ff
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO

--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: 7ba47286b415dd0d681400492c84e7441cd2d3ff
+    commit_sha: 97fd2ed7eb8e49ffbffae7e42239cace771d16cc
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO

--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: 97fd2ed7eb8e49ffbffae7e42239cace771d16cc
+    commit_sha: 624234d8a30cb2661a2e3d7fb52f841f589a867e
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO


### PR DESCRIPTION
Updates **[ESP32] Hotspot Arcade** (GPIO) from 0.3 to **1.1** by re-pinning `commit_sha`. `fap_version` is `1.1` (up from `0.3`).

Source: https://github.com/tarikbc/hotspot-arcade — commit `e83d9a4` (tagged v1.1.0), building the `flipper/hotspot-arcade` subdir. The phone web bundle, content packs, and ESP32 firmware ship bundled inside the .fap, so a fresh install needs no SD setup.

Highlights since 0.3:
- **Flash more than one board:** "Install Firmware" opens a board picker for the official Flipper WiFi Dev Board (ESP32-S2) or an ESP32 WROOM board. Each board's firmware is bundled, so it stays an offline, no-computer flash.
- Four games are content-pack driven (Trivia, Would You Rather, Word Scramble, Draw & Guess), six packs each bundled in; user packs still take precedence.
- Game boards render correctly in phone browsers, including iOS/Safari (Reversi, Connect Four, Tic-Tac-Toe).
- New angry reaction; reactions scoped to your screen and showing the sender; lobby chat on the Flipper console.
- Rematch/challenge edge cases fixed.
- Firmware v11.

Note: because the .fap bundles two board firmwares now, the **first launch (and each update) can take up to 2 minutes** while it unpacks to the SD card. This is called out in the app description.

Full changelog is in the bundled `catalog/changelog.md`.
