### PR TITLE
flipper_share_nfc: v1.5 - the fastest direct file transfer so far

### DIFF
--- a/applications/NFC/flipper_share_nfc/manifest.yml
+++ b/applications/NFC/flipper_share_nfc/manifest.yml
@@ -1,0 +1,24 @@
+# PR this file to: https://github.com/flipperdevices/flipper-application-catalog/
+# applications/NFC/flipper_share_nfc/manifest.yml
+
+# Check:
+# python3 -m venv venv
+# pip install -r tools/requirements.txt
+# python3 tools/bundle.py --nolint applications/NFC/flipper_share_nfc/manifest.yml bundle.zip
+
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/lomalkin/flipper-zero-apps.git
+    commit_sha: 94715405347e153c53deff596e247bc70184fd0a
+    subdir: flipper_share_nfc
+description: "@README_catalog.md"
+changelog: "@CHANGELOG.md"
+screenshots:
+  - screenshots/1.png
+  - screenshots/2.png
+  - screenshots/3.png
+  - screenshots/4.png
+  - screenshots/5.png
+  - screenshots/6.png
+  - screenshots/7.png


### PR DESCRIPTION
# Application Submission

- flipper_share_nfc: v1.5 - the fastest option for file transfer in Flipper Share family (7KB/s)
- Sending big files is not a pain anymore
- It is a fork of original flipper_share (v1.5) with new transport, high-level protocol is the same

# Extra Requirements 

- Take two flippers
- Select file to transfer on first one
- Select Receive file on second
- Align it back to back and see the file transfer progress

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- Helped me to create NFC layer used as a transport of Flipper Share protocol. I have tested it for a week for reliability before publish.
- Check apps docs consistency

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
