### PR TITLE
Log the folder being skipped, not a leftover filename

### DIFF
--- a/tools/bundle.py
+++ b/tools/bundle.py
@@ -404,7 +404,7 @@ class AppBundler:
                 # Exclude hidden folders and "dist" folder with build artifacts
                 for folder_name in subfolders.copy():
                     if folder_name.startswith(".") or folder_name == "dist":
-                        self._log.debug(f"Skipping folder {filename}")
+                        self._log.debug(f"Skipping folder {folder_name}")
                         subfolders.remove(folder_name)
                     # Exclude source code folder if requested
                     if skip_source_code and self._code_dir == Path(folder, folder_name):


### PR DESCRIPTION
The "skipping folder" debug line in `_build_package` prints `filename`, which isn't the folder it just skipped. The `os.walk` loop unpacks `folder, subfolders, filenames` — there's no `filename` in that scope, so it picks up whatever the name was last bound to further down, where the file loop runs.

In practice that means the message names a file instead of the folder. Every bundle run hits it, since `_fetch_sources()` always clones, so `code/.git` is always there to be pruned:

```
Skipping folder manifest.yml
```

with `.git` being the thing actually skipped. `folder_name` is the loop variable right above it.

The neighbouring "skipping source code folder" line already prints a path, so this looks like a copy-paste slip rather than intent.
