### PR TITLE
Add WoL Flipper 1.1

### DIFF
--- a/applications/GPIO/wol_flipper/manifest.yml
+++ b/applications/GPIO/wol_flipper/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/keetsta/wol-flipper.git
-    commit_sha: 9da400586f01bd4eef529b22bfb473efcaed36db
+    commit_sha: d93e9a6f11245745a97957487a51bcbdcc0f5921
 
 short_description: Wake-on-LAN over the ESP32-S2 WiFi dev board, with a built in flasher
 

--- a/applications/GPIO/wol_flipper/manifest.yml
+++ b/applications/GPIO/wol_flipper/manifest.yml
@@ -1,0 +1,15 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/keetsta/wol-flipper.git
+    commit_sha: 9da400586f01bd4eef529b22bfb473efcaed36db
+
+short_description: Wake-on-LAN over the ESP32-S2 WiFi dev board, with a built in flasher
+
+description: "@DESCRIPTION.md"
+changelog: "@changelog.md"
+
+screenshots:
+  - "screenshots/menu.png"
+  - "screenshots/board.png"
+  - "screenshots/sending.png"


### PR DESCRIPTION
# Application Submission

Wake-on-LAN sender. The Flipper has no network of its own, so the app drives the
official ESP32-S2 WiFi dev board over UART: the board joins Wi-Fi and puts the magic
packet on the wire as a UDP broadcast.

That board needs a small companion firmware, and the app writes it itself over the same
header, no computer involved. Before overwriting anything it can dump the board's whole
4 MB flash to the SD card and put it back later, so whatever was there before returns
exactly as it was. Every write is MD5 verified by the target.

- Up to 16 saved targets: name, MAC entered as six hex bytes, broadcast address, port
- Sends to the subnet directed broadcast as well as the configured address, because
  access points differ in which of the two they bridge onto the wired segment
- Wi-Fi scan fills the SSID in from a list; failures report the actual reason, whether
  the network was not on the air, the key was refused, or the board never answered
- Built in flasher: backup, flash, restore, with automatic bootloader entry on the
  official board

# Extra Requirements

The official Flipper WiFi dev board (ESP32-S2) on the GPIO header. The companion
firmware ships inside the .fap and is written by the app, so no PC, esptool or separate
downloads are needed. Third party ESP32-S2 boards work as well, but need BOOT and RESET
pressed by hand before flashing, since they leave those lines unconnected.

Vendored dependency: espressif/esp-serial-flasher v2.0.0, Apache-2.0, trimmed to the
ESP32-S2 stub to keep the FAP small. Attribution and the full list of modifications are
in the repository README. Everything else is MIT.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Fully AI generated (explain what all the generated code does in moderate detail).

The code was written by Claude under my direction. I specified the behaviour, ran every
iteration on real hardware, and the bugs I hit there drove most of the changes.

What the generated code does. On the Flipper: a scene based UI for targets and Wi-Fi
settings, a UART client for the board's line protocol, and a port of esp-serial-flasher
that reads and writes the ESP flash over SLIP using the stub loader with MD5
verification. On the board: an Arduino firmware exposing a tab separated line protocol
that joins Wi-Fi, scans for networks, builds the 102 byte magic packet and broadcasts
it, plus LED status.

Validated with `python3 tools/bundle.py applications/GPIO/wol_flipper/manifest.yml bundle.zip`,
with lint enabled rather than `--nolint`.

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
