### PR TITLE
Update CK42X PassVault to v0.4.5

### DIFF
--- a/applications/Tools/ck42x_passvault/README.md
+++ b/applications/Tools/ck42x_passvault/README.md
@@ -1,5 +1,5 @@
 # CK42X PassVault
 
-Catalog manifest for [CK42X PassVault](https://github.com/lordbuffcloud/flipper-ck42x-passvault), a Flipper Zero external app for PIN-gated encrypted password storage, RNG password generation, and explicit opt-in USB HID password typing.
+Catalog manifest for [CK42X PassVault](https://github.com/lordbuffcloud/flipper-ck42x-passvault), a Flipper Zero external app for PIN-gated encrypted password storage, RNG password generation, explicit opt-in USB HID password typing, and experimental FIDO2 WebAuthn registration and authentication.
 
-Security note: v0.4 stores the active vault as AES-GCM encrypted app data and requires a master PIN, but it is still an unaudited Flipper utility. A compromised device, weak PIN, shoulder surfing, debug access, or modified firmware can still expose vault contents.
+Security note: PassVault stores passwords and FIDO credentials in separate AES-GCM encrypted app-data files behind the master PIN. It remains an experimental, unaudited Flipper utility. Flipper Zero has no secure element, and this build is not FIDO certified. Keep a backup authenticator and account recovery method.

--- a/applications/Tools/ck42x_passvault/README.md
+++ b/applications/Tools/ck42x_passvault/README.md
@@ -1,5 +1,5 @@
 # CK42X PassVault
 
-Catalog manifest for [CK42X PassVault](https://github.com/lordbuffcloud/flipper-ck42x-passvault), a Flipper Zero external app for PIN-gated encrypted password storage, RNG password generation, explicit opt-in USB HID password typing, and experimental FIDO2 WebAuthn registration and authentication.
+Catalog manifest for [CK42X PassVault](https://github.com/lordbuffcloud/flipper-ck42x-passvault), a Flipper Zero external app for PIN-gated encrypted password storage, saved-entry editing, RNG password generation, explicit opt-in USB HID password typing, macOS ANSI keyboard setup, and experimental FIDO2 WebAuthn registration and authentication.
 
 Security note: PassVault stores passwords and FIDO credentials in separate AES-GCM encrypted app-data files behind the master PIN. It remains an experimental, unaudited Flipper utility. Flipper Zero has no secure element, and this build is not FIDO certified. Keep a backup authenticator and account recovery method.

--- a/applications/Tools/ck42x_passvault/manifest.yml
+++ b/applications/Tools/ck42x_passvault/manifest.yml
@@ -2,8 +2,8 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/lordbuffcloud/flipper-ck42x-passvault.git
-    commit_sha: 9eb3f8b2f54b2489204dfa4cd168de09e5c54bfc
-short_description: Encrypted password vault, opt-in HID typing, and experimental FIDO2 authentication.
+    commit_sha: e38cdbb90fbe048d4f58d84d2ec6c6686fd19e54
+short_description: Encrypted editable password vault, macOS HID setup, and experimental FIDO2.
 description: "@catalog_description.md"
 changelog: "@catalog_changelog.md"
 screenshots:

--- a/applications/Tools/ck42x_passvault/manifest.yml
+++ b/applications/Tools/ck42x_passvault/manifest.yml
@@ -2,8 +2,8 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/lordbuffcloud/flipper-ck42x-passvault.git
-    commit_sha: b51e3a71316b0e3d4fa3e52018c41113b805ef7b
-short_description: CK42X.com PIN-gated encrypted password vault with RNG generation and opt-in HID password typing.
+    commit_sha: 9eb3f8b2f54b2489204dfa4cd168de09e5c54bfc
+short_description: Encrypted password vault, opt-in HID typing, and experimental FIDO2 authentication.
 description: "@catalog_description.md"
 changelog: "@catalog_changelog.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

- Updates CK42X PassVault from v0.4 to v0.4.5.
- Adds editing for saved Name, Username, and Password fields with prefilled values, explicit confirmation, and in-memory rollback if encrypted save fails.
- Adds explicit macOS ANSI keyboard setup while retaining the standard Flipper HID identity.
- Keeps HID active after successful macOS setup so repeated password injections reuse one keyboard session.
- Includes the experimental clean-room FIDO 2.0 authenticator with CTAPHID, CTAP2, ES256, non-resident credentials, allow-list matching, cancellation, signature counters, and physical Approve/Deny user presence.
- Stores FIDO credentials in a separate AES-GCM encrypted app-data file and restores the previous USB configuration when FIDO2 mode exits.
- Updates catalog description, changelog, and security/recovery guidance.

# Extra Requirements

- No extra hardware beyond a Flipper Zero and USB cable.
- FIDO2 mode requires a host/browser that supports USB security keys.
- The feature is experimental. Flipper Zero has no secure element, and the app is not FIDO certified. Users should keep a backup authenticator and account recovery method.

# Author Checklist (Fill this out)

- [x] I've read the contribution guidelines and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I validated the manifest with `python tools/bundle.py --nolint applications/Tools/ck42x_passvault/manifest.yml /tmp/ck42x_passvault_0.4.5_bundle.zip`

# Verification

- Official catalog bundle validation passed against source commit `e38cdbb90fbe048d4f58d84d2ec6c6686fd19e54`.
- The catalog-built FAP is 46,760 bytes with SHA-256 `29551932b2efc419114d0281e7586b981654f51c062b51eb1ae518c6fd4a7fc9`, byte-identical to the GitHub and CK42X release artifact.
- Saved-entry editing, macOS HID lifecycle, CTAPHID/CTAP2 runtime, navigation, and password-preset host contracts passed.
- uFBT compile/link and APPCHK passed for target 7 / API 87.1.
- Physical Chromium WebAuthn registration/authentication, ES256 signature verification, counter advancement, credential persistence after FIDO restart, and USB restoration were verified on Oaspote.
- The retained macOS HID lifecycle is covered by source contracts and target compilation; repeated-injection behavior has not yet received final physical confirmation for this exact v0.4.5 artifact.

# AI usage disclosure (Fill this out)

- Disclosure: fully AI generated.

The clean-room CTAPHID/CTAP2 runtime, encrypted credential persistence, saved-entry editing, macOS HID lifecycle, test suites, integration code, and documentation were generated by an AI coding agent under the repository owner's direction. The owner performed the physical approval steps. The implementation was reviewed through strict host tests, uFBT/APPCHK, native CTAP2 probes, cryptographic signature verification, Chromium WebAuthn registration/authentication, restart persistence testing, USB lifecycle verification, and catalog bundle validation.

# Reviewer checklist

For upstream maintainers: bundle validity, source review, and hardware verification remain reviewer decisions.
