### PR TITLE
Update Hotspot Arcade to 1.5

### DIFF
--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: a3f03817de1b49b2d970bb4e1cea844c7dd7576a
+    commit_sha: c7f49315f5026510e5bab0fd94049b9d0eae18ee
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO

--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: 1ebab6728e0614affadca774709034501de2d094
+    commit_sha: a221c466fd5619529b48b4961dad3d240d2aa00e
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO

--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: c7f49315f5026510e5bab0fd94049b9d0eae18ee
+    commit_sha: 1ebab6728e0614affadca774709034501de2d094
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO


### PR DESCRIPTION
Bumps Hotspot Arcade to 1.3 (pins the v1.3.0 commit c7f4931). The description, changelog, and screenshots resolve from that commit.
UPD: Set to 1.5 release

Adds a 13th game, Spectrum, a Wavelength-style guessing game: one player sees a hidden target on a spectrum and gives a clue, everyone else slides a dial to guess. Firmware v14. The 1.2 release (Guess the Color, Battleship) is also picked up in the changelog now.

Release: https://github.com/tarikbc/hotspot-arcade/releases/tag/v1.3.0