### PR TITLE
Add CCID app to the catalog

### DIFF
--- a/applications/USB/ccid_test/manifest.yml
+++ b/applications/USB/ccid_test/manifest.yml
@@ -1,0 +1,12 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/kidbomb/flipper-ccid-app.git
+    commit_sha: 60cf9352f0e95c266cd065e1f5f7627851f27d19
+
+description: "@README.md"
+
+changelog: "@./docs/changelog.md"
+
+screenshots:
+  - screenshots/ss0.png


### PR DESCRIPTION
# Application Submission

Emulates a USB smart card reader with a virtual ISO7816 T=0 card. Source lives at https://github.com/kidbomb/flipper-ccid-app

This app used to live in firmware. It is currently being removed on the following PR: https://github.com/flipperdevices/flipperzero-firmware/pull/4431

# Extra Requirements 

 - No additional hardware or software is required

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- [ Describe how AI was used in this PR if it was used ]

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
