### PR TITLE
Add NFC Canary

### DIFF
--- a/applications/NFC/nfc_canary/manifest.yml
+++ b/applications/NFC/nfc_canary/manifest.yml
@@ -1,0 +1,45 @@
+# Flipper Apps Catalog manifest.
+#
+# This file is NOT used by this repository. It is submitted as a pull request
+# to flipperdevices/flipper-application-catalog, placed at:
+#   applications/NFC/nfc_canary/manifest.yml
+#
+# Paths in this file are relative to the app source root (this repo), because
+# the catalog builds from the sourcecode reference below.
+#
+# On each release: bump `version` here and `fap_version` in application.fam to
+# match, update commit_sha, and add a changelog.md entry.
+#
+# See ../docs/RELEASING.md for the full checklist.
+
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/antitree/nfc_canary.git
+    commit_sha: edc2dc17cf5d6e259430bc6abc7b7c454a195af5
+
+name: NFC Canary
+id: nfc_canary
+category: NFC
+version: "0.2"
+author: antitree
+
+short_description: Alerts you by vibration when someone scans you over NFC.
+
+# Not @README.md: the catalog supports only limited Markdown (headers 1-2,
+# bold/italic, lists, links) and the README relies on image tables and code
+# blocks that would not render.
+description: "@./catalog/description.md"
+changelog: "@./changelog.md"
+
+icon: nfc_canary.png
+
+# 128x64 1-bit, the panel's native resolution.
+screenshots:
+  - catalog/screenshots/01-status.png
+  - catalog/screenshots/02-alarm.png
+  - catalog/screenshots/03-events.png
+  - catalog/screenshots/04-settings.png
+
+targets:
+  - f7


### PR DESCRIPTION
Adds **NFC Canary**, a passive 13.56 MHz reader detector.

Carried in a pocket or bag, it alerts the user — by vibration first — when a reader interrogates them. It uses the ST25R3916's hardware External Field Detector to listen for a reader's carrier and never transmits anything of its own.

Threat tiering keeps it usable day to day: ambient 13.56 MHz is everywhere, so a brief carrier is logged silently, a sustained one vibrates, and only the top tier sounds an alarm. Vibration and sound are independently configurable (pattern, tone, volume, minimum tier), and there is a settings-screen test so the alert can be auditioned without a reader.

**Scope:** defensive only. It reports that an interrogation happened — time, tier, duration — and never captures, stores, or replays card contents.

### Checklist

- [x] Public GitHub repository: https://github.com/antitree/nfc_canary
- [x] MIT licensed (permits binary distribution)
- [x] Builds with uFBT against official firmware — CI runs release and dev channels on every push
- [x] Icon is 10x10 1-bit PNG
- [x] Screenshots captured via qFlipper at native 128x64, unmodified
- [x] Unique `id` (`nfc_canary`) and `version` (`0.2`)
- [x] `description` and `changelog` verified against `BasicFormattingEnforcingExtension`
- [x] Manifest parses with `flipp_catalog.manifest.ApplicationManifest`

`description` points at `catalog/description.md` rather than the README, since the README uses blockquotes and images that the sanitizer rejects.
