### PR TITLE
[Infrared] Samsung AC Remote: add v1.0

### DIFF
--- a/applications/Infrared/samsung_ac_remote/manifest.yml
+++ b/applications/Infrared/samsung_ac_remote/manifest.yml
@@ -1,0 +1,11 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/dappermint/samsung-ac-remote-flipper-app.git
+    commit_sha: 9aa864949b60e290ce30dcfb62533202675b36d9
+short_description: Samsung Electric Air Conditioner remote control
+description: "@./docs/description.md"
+changelog: "@./docs/changelog.md"
+screenshots:
+  - screenshots/ss0.png
+  - screenshots/ss1.png


### PR DESCRIPTION
# Application Submission

- Samsung A/C infrared remote. Sends the full stateful Samsung frame on every press: power, mode (cool/heat/dry/fan/auto), temperature 16-30 °C, fan speed and vertical swing, with the dual-section checksum. Protocol based on the IRremoteESP8266 reverse engineering. Settings persist between launches.

# Extra Requirements

- None, uses the built-in IR transmitter.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

- [ Describe how AI was used in this PR if it was used ]

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
