### PR TITLE
Update Hotspot Arcade to 1.7

### DIFF
--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,11 +2,11 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: a221c466fd5619529b48b4961dad3d240d2aa00e
+    commit_sha: b2792aae35444503943ba63a2725bad14fbf5900
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO
-short_description: Offline multiplayer party games on the ESP32-S2 WiFi board; friends join your WiFi and play in their phone browser.
+short_description: Offline multiplayer party games on an ESP32 WiFi board; friends join your WiFi and play in their phone browser.
 description: "@catalog/DESCRIPTION.md"
 changelog: "@catalog/changelog.md"
 screenshots:


### PR DESCRIPTION
Bumps Hotspot Arcade to 1.7 (pins commit b2792aa — the v1.7.0 release plus a one-line catalog-changelog wording fix). The description, changelog, and screenshots resolve from that commit.

Since 1.5: three more games — Kiss Marry Kill (1.4), Chess (1.6, full FIDE rules with a 5-minute blitz clock), and Secrets (1.7) — for sixteen total. Also phone voting to switch the active game, and more reliable hosting: the phone web app now lives in the board's flash instead of RAM, so the hotspot no longer runs low on memory as more phones join. Firmware v19. The 1.6 release (Chess) is picked up in the changelog now.

Release: https://github.com/tarikbc/hotspot-arcade/releases/tag/v1.7.0
