### PR TITLE
Add FMTX app - an MP3 FM transmitter with Flipper's radio

### DIFF
--- a/applications/Sub-GHz/fmtx/manifest.yml
+++ b/applications/Sub-GHz/fmtx/manifest.yml
@@ -1,0 +1,11 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/yo3gnd/fmtx
+    commit_sha: 12fd39a84e5d2f97f76653fa223befb182207498
+description: "@market/README.md"
+changelog: "@market/CHANGELOG.md"
+screenshots:
+  - market/s1.png
+  - market/s2.png
+  - market/s3.png


### PR DESCRIPTION
# Application Submission

Adds FMTX 0.0.10 to the Sub-GHz catalogue. It plays MP3 files over the Flipper’s CC1101 as FM audio, with selectable files and transmit frequency.

It has been tested with cheap LPD433 walkie-talkies. This is a slightly unreasonable use of the radio, but it works—and at times not half badly.


# Extra Requirements 

A portable radio (HT) that can receive FM in Flipper's bands, or an SDR in FM mode.


# Author Checklist (Fill this out)

- [X] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [X] I own the code I'm submitting or have code owner's permission to submit it
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [X] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

AI was used mostly for linting and some cleanup. Very little was generated

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
