### PR TITLE
Add Net Calculator 1.0

### DIFF
--- a/applications/Tools/net_calculator/manifest.yml
+++ b/applications/Tools/net_calculator/manifest.yml
@@ -1,0 +1,13 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/WolfRorDev/Net-Calculator-for-Flipper-Zero.git
+    commit_sha: 9e02075a4d9927ca898f51b059262d00fab1253b
+
+short_description: Offline IPv4 VLSM subnet calculator
+description: "@README.md"
+changelog: "@changelog.md"
+
+screenshots:
+  - screenshots/main.png
+  - screenshots/results.png

--- a/applications/Tools/net_calculator/manifest.yml
+++ b/applications/Tools/net_calculator/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/WolfRorDev/Net-Calculator-for-Flipper-Zero.git
-    commit_sha: 9e02075a4d9927ca898f51b059262d00fab1253b
+    commit_sha: ae8088442a402f0f75700e9a9927fb64023b3c21
 
 short_description: Offline IPv4 VLSM subnet calculator
 description: "@README.md"


### PR DESCRIPTION
# Application Submission

Net Calculator is an offline IPv4 VLSM subnet calculator for Flipper Zero.

It allows the user to enter a parent IPv4 network and multiple required host counts, then calculates VLSM subnet allocations including network address, prefix, first host, last host, and broadcast address.

The application also provides a list of entered subnet requests with individual removal and detects when the requested subnets exceed the available parent network address space.

# Extra Requirements

No extra hardware or software is required.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).

- [ ] Fully AI generated (explain what all the generated code does in moderate detail).

AI assistance was used to port my original VLSM calculation algorithm to the Flipper Zero C/Furi API, implement the device UI, and help prepare project documentation.

The original VLSM algorithm and Net Calculator project were created by me. I also manually modified and reviewed the Flipper Zero port, and tested it on real Flipper Zero hardware.

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality