### PR TITLE
Update Android KB Bridge (android_keyboard_bridge) to 0.5.8

### DIFF
--- a/applications/Bluetooth/android_keyboard_bridge/manifest.yml
+++ b/applications/Bluetooth/android_keyboard_bridge/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/andybeg/AndroidFlipperZeroKBD.git
-    commit_sha: 2489d0db6cb590f83cd60280995ebd2e3b14f090
+    commit_sha: bda6bb236b50b5877a9d54b0a2ed613cb42427e1
     subdir: flipper/android_keyboard_bridge
 description: "@README.md"
 changelog: "@changelog.md"


### PR DESCRIPTION
# Application Update

**Android KB Bridge** — bump catalog pin from **0.5.2** → **0.5.8**.

Source commit: `bda6bb236b50b5877a9d54b0a2ed613cb42427e1`  
Release: https://github.com/andybeg/AndroidFlipperZeroKBD/releases/tag/v0.5.8

FAP behavior is unchanged since 0.5.2 (version-align bumps); companion Android app gained CLDR language packs, Settings UX polish, and a new launcher icon. Catalog package remains the C FAP only.

Validated locally:
`python3 tools/bundle.py --nolint applications/Bluetooth/android_keyboard_bridge/manifest.yml bundle.zip` → version `0.5.8`.

# Author Checklist

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint …`

# AI usage disclosure

- [x] Partially AI assisted (PR / catalog packaging prepared with Cursor; FAP source reviewed and hardware-tested by maintainer).

Made with [Cursor](https://cursor.com)