### PR TITLE
Add TPMS Bridge 1.0

### DIFF
--- a/applications/Sub-GHz/tpms_bridge/manifest.yml
+++ b/applications/Sub-GHz/tpms_bridge/manifest.yml
@@ -1,0 +1,14 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/VishovVladimir/flipper-zero-tpms.git
+    commit_sha: a93a5daf541839301aeaddbe8efa855d14e89c3c
+    subdir: flipper/tpms_bridge
+
+description: "@README.md"
+changelog: "@changelog.md"
+screenshots:
+  - screenshots/4.png
+  - screenshots/3.png
+  - screenshots/2.png
+  - screenshots/1.png


### PR DESCRIPTION
# Application Submission

TPMS Bridge reads Renault tyre pressure sensors on 433.92 MHz and shows what they report directly on the Flipper screen: sensor ID, pressure, temperature and signal level. Reception starts as soon as the app is opened, so no computer is needed.

The stock firmware cannot read these sensors: `subghz rx` / `rx_raw` load OOK presets while the sensor transmits 2-FSK, and a Sub-GHz Read RAW capture drops pulses shorter than `te_short = 50 us` (`lib/subghz/protocols/raw.c`), which is exactly this protocol's chip duration. So the app configures the CC1101 for 2-FSK itself and demodulates on the device.

Features:

- Sensor list, up to 8 remembered, with a four-step signal ladder per row. The signal level is what tells the wheels apart — walk around the car and watch which row rises. Stale rows (silent for over a minute) are drawn as outlines.
- Detail screen: pressure in bar, PSI and kPa, temperature, current signal level and a 10-second peak hold, frame counter, age of the last frame, protocol flags.
- Wakes a parked sensor with a 125 kHz field through the RFID coil: a single 0.7 s pulse on Right, or a repeating pulse every 5 s on Left.
- Streams decoded frames as line-delimited JSON over the USB CLI (`tpms_rx`), carrying both the parsed fields and the raw 9 bytes.

The app only receives on Sub-GHz; it never transmits there.

# Extra Requirements

No hardware add-ons. It needs a Renault-family TPMS sensor to show anything — verified on a real 407003VU0B, both on the bench and on a moving car with all four wheels reporting at once. rtl_433 documents the same protocol on Renault Clio, Captur and Zoe (sensor 407004CB0B) and possibly Dacia Sandero.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Fully AI generated (explain what all the generated code does in moderate detail).

The C sources were written by Claude (Anthropic) in an interactive session where I specified the requirements, tested every iteration on real hardware with a real sensor, and reviewed the result. What the code does, file by file:

- `tpms_preset.h` — CC1101 register set for 2-FSK, 20 kBaud, 28.56 kHz deviation, 325 kHz RX bandwidth, with GDO0 in asynchronous serial mode. Taken from ProtoView's published TPMS preset, which is proven against real Renault sensors.
- `tpms_session.c` — owns the radio through the `subghz_devices` API. The async RX callback runs in interrupt context and only pushes `LevelDuration` pairs into a `FuriStreamBuffer`; decoding is driven by the owner calling `tpms_session_pump()`, so the same code serves both the on-device thread and the CLI command thread. RSSI is sampled when a batch arrives rather than after decoding, otherwise the transmission is already over and the reading is noise. Also emits the 125 kHz wake pulse without muting the receiver, because the sensor answers immediately.
- `tpms_renault.c` — the protocol. Intervals are split into ~50 us chips, chips are searched for the 20-chip sync `01010101010101010110`, then Manchester-decoded into 9 bytes and checked with CRC-8 (poly 0x07, init 0x00), per rtl_433's `tpms_renault.c`. Four state machines run in parallel because the demodulator polarity is unknown and, on the real sensor, the sync polarity does not match the Manchester convention in the data — the combination whose CRC checks out wins.
- `tpms_store.c` — a fixed table of 8 sensors in insertion order, so rows never jump; the longest-silent entry is evicted when full. Holds a rolling 10-second signal peak, which is what makes walking around the car useful.
- `tpms_view.c` — the two screens, drawn with integer arithmetic only (`raw * 75` for kPa hundredths and so on), since the firmware printf need not support `%f`.
- `tpms_bridge.c` — key handling and arbitration of the radio: local reception runs whenever the radio is free and yields it to a USB session on request, taking it back when that session ends. It also blocks unloading the app while a CLI session is alive, since the command code lives in the same .fap, and handles `FuriSignalExit` so `loader close` works.
- `tpms_cli.c` — the `tpms_rx` command. Writes go through a bounded-wait helper instead of printf: if the host stops reading without closing the command, a blocking write would hold the radio forever.
- `tpms_lf.c` — the 125 kHz field via `furi_hal_rfid_tim_read_start`.

Verification, all of it run before submitting: the decoder is exercised on the host by `flipper/decoder_test` against ProtoView's published test vector (ID 7ad779, 243.75 kPa, 22 C) plus all polarity combinations, ±15% timing jitter and corrupted-frame rejection, with a real captured frame pinned as a regression. `flipper/view_test` renders the same screen code against a canvas emulator and fails on text leaving 128x64 or colliding with another column — it caught several layout bugs that would otherwise only be visible on the device. A separate Python implementation of the same protocol has 51 tests. On hardware, the app has been used to read a real sensor on the bench and all four wheels of a moving car