### PR TITLE
[GPIO] Add WiFi Internet Watch v1.1

### DIFF
--- a/applications/GPIO/wifi_internet_watch/manifest.yml
+++ b/applications/GPIO/wifi_internet_watch/manifest.yml
@@ -1,0 +1,26 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/DruzhininPavel/wifi-internet-watch-flipper.git
+    commit_sha: 6d171ccef671ab8de36e8081c25de2fd752a6050
+short_description: Select a WiFi network and monitor internet availability through ESP-AT
+description: |
+  WiFi Internet Watch connects an official Flipper Zero Wi-Fi Developer Board
+  running ESP-AT to a selected wireless network and checks internet availability
+  every 60 seconds.
+
+  **Features**
+
+  - Scans and selects nearby Wi-Fi networks
+  - Full lowercase, uppercase, numeric, and symbol password keyboard
+  - Saves, updates, and forgets up to 16 network credentials
+  - Shows online, offline, and Wi-Fi connection states
+  - Plays a notification when internet connectivity returns
+
+  The ESP32-S2 board must run ESP-AT configured for GPIO17 and GPIO18 at 115200
+  baud with hardware flow control disabled. Setup instructions are available in
+  the source repository.
+changelog: "@docs/changelog.md"
+screenshots:
+  - screenshots/password-keyboard.png
+  - screenshots/scanning.png

--- a/applications/GPIO/wifi_internet_watch/manifest.yml
+++ b/applications/GPIO/wifi_internet_watch/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/DruzhininPavel/wifi-internet-watch-flipper.git
-    commit_sha: 6d171ccef671ab8de36e8081c25de2fd752a6050
+    commit_sha: da36aaa3c4f7db1a1ee854f89d6747548beb654a
 short_description: Select a WiFi network and monitor internet availability through ESP-AT
 description: |
   WiFi Internet Watch connects an official Flipper Zero Wi-Fi Developer Board


### PR DESCRIPTION
# Application Submission

WiFi Internet Watch scans nearby Wi-Fi networks through an ESP-AT Wi-Fi Dev Board, connects to a selected network, and checks internet availability every 60 seconds. It includes a full password keyboard, persistent storage for up to 16 credentials, saved-network editing and deletion, visual status, and a notification when connectivity returns.

# Extra Requirements

Requires the official Flipper Zero Wi-Fi Developer Board running ESP-AT. The ESP32-S2 UART must use GPIO17/GPIO18 at 115200 baud with hardware flow control disabled. Reproducible setup details and the factory parameter CSV are included in the source repository.

# Author Checklist

- [x] I've read the contribution guidelines and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have validated the manifest with `python3 tools/bundle.py --nolint applications/GPIO/wifi_internet_watch/manifest.yml bundle.zip`

# AI usage disclosure

- [x] Fully AI generated

The implementation was generated by GitHub Copilot under the author's direction and tested on the author's physical Flipper Zero and official Wi-Fi Developer Board. It implements the GUI, LPUART ESP-AT transport, Wi-Fi scan/join flow, internet monitoring, password keyboard, and credential persistence. The author performed the hardware setup, interaction testing, and acceptance of the resulting behavior.

# Reviewer Checklist

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've run this application and verified its functionality