### PR TITLE
Add Fake Chip Detector 0.7 (GPIO)

### DIFF
--- a/applications/GPIO/fake_chip_detector/manifest.yml
+++ b/applications/GPIO/fake_chip_detector/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/hleserg/flipper-fake-chip-detector.git
-    commit_sha: f7df74a69e4545b2c311a81b2749ed4db11ed11c
+    commit_sha: a412eeb153c9c0c9e6b7347068537a666f03526c
     subdir: fake_chip_detector
 short_description: Check whether an I2C sensor really is the chip it was sold as, before you solder it in.
 description: "@docs/catalog_description.md"

--- a/applications/GPIO/fake_chip_detector/manifest.yml
+++ b/applications/GPIO/fake_chip_detector/manifest.yml
@@ -1,0 +1,14 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/hleserg/flipper-fake-chip-detector.git
+    commit_sha: f7df74a69e4545b2c311a81b2749ed4db11ed11c
+    subdir: fake_chip_detector
+short_description: Check whether an I2C sensor really is the chip it was sold as, before you solder it in.
+description: "@docs/catalog_description.md"
+changelog: "@docs/changelog.md"
+screenshots:
+  - screenshots/04_question.png
+  - screenshots/05_allgood.png
+  - screenshots/12_live_vl6180x.png
+  - screenshots/02_wiring.png


### PR DESCRIPTION
# Application Submission

**Fake Chip Detector** — tells you whether an I²C sensor really is the chip it was sold as,
before you solder it in.

Modules sold as a BME280 frequently carry a BMP280 die; "MPU9250" boards often contain an
MPU6500 with no magnetometer in it. Plug the module into the GPIO header, scan, and the app reads
the chip's factory ID register — the number burned into the die rather than printed on the
package — names the part, and then asks the one question it cannot answer itself: is this what
you bought?

First submission, version 0.7.

- **80 chips** in the database, 51 identified by ID register and 29 by address alone. Address
  collisions are resolved by probing every candidate that shares an address. 8- and 16-bit
  register indices and 16-bit values, so ST time-of-flight parts and TI power monitors are
  covered alongside the usual WHO_AM_I chips.
- **A report** written for a seller or a courier: plain statement first, why a factory ID cannot
  be forged second, register values last. Readable on the device and saved to the SD card.
- **Wiring diagnosis** with live per-line detection — a missing pull-up, a line shorted to
  ground, SDA shorted to SCL, or the module plugged into the wrong header pins entirely, which
  it finds by sweeping the other pins for the module's pull-ups.
- **13 live tests.** An ID register is one byte and a byte can be copied; a working sensor
  cannot. Each test needs nothing but a hand and a breath — breathe on an AHT or SHT, cover a
  BH1750, tip an MPU6050 or ADXL345, wave at an APDS9960, point an MLX90614 at your palm, watch
  a DS3231 tick, blink an SSD1306, turn a BNO055 through a figure-8, hold a hand in front of a
  VL6180X. This matters most for the parts with no ID register at all, where presence is
  otherwise the only thing provable.
- **1-Wire scanning** on pin 17, with a real temperature conversion, so a DS18S20 sold as a
  DS18B20 is caught.
- Tests can also be **loaded from the SD card as .fal plugins** without rebuilding the app. Ones
  loaded that way are marked SD on screen, because a built-in test was written against a
  datasheet and reviewed in the repository and one from the card is somebody else's code.

The app is deliberately conservative about what it claims. A chip with no ID register is
reported as present, never as genuine. A device matching nothing is unidentified, not "fake" —
far more often that is a gap in the database. Only a partial match, where some of a known chip's
IDs are right and others wrong, is called a likely counterfeit. Every register constant in the
database is taken from the manufacturer's datasheet, cited in the source.

It is a beta, and the version number says so: one part has been driven end to end on real
silicon, and twelve of the thirteen live tests have never met the chip they were written for.
Everything is built and reviewed; that is not the same as somebody's actual sensor saying yes.

# Extra Requirements

An I²C sensor module to test, and four jumper wires to the GPIO header — pin 8 GND, pin 9 3V3,
pin 15 SDA, pin 16 SCL. Nothing needs to be soldered, which is the point. No add-on board, no
companion app, no network.

For 1-Wire, a DS18B20-class probe on pin 17.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

Validated both ways — with `--nolint` and without, so `ufbt lint` passes too. Builds clean
against the official SDK 1.4.3 (API 87.1).

# AI usage disclosure (Fill this out):

- [ ] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).
- [x] Fully AI generated (explain what all the generated code does in moderate detail).

The application was written by Claude (Anthropic) working from my direction, review and hardware
testing. Being straightforward about that: essentially all of the C in the repository was
generated, over many iterations, with me specifying behaviour, rejecting approaches, and running
the result on a Flipper with real sensors attached.

What the code does, by file:

- `fake_chip_detector.c` — the whole UI: menu, wiring guide, scan and results, verdict and
  report screens, the live-test screen and browser, saved reports, settings. Views and a
  ViewDispatcher, one worker thread for the bus and one for animation.
- `chip_db.c` — the database. Each entry is a name, a description, the addresses the part can
  sit at, and the ID registers with their expected values. Every constant carries a datasheet
  citation in a comment; parts whose datasheets could not be verified were dropped rather than
  guessed at, because a wrong constant here accuses a genuine chip of being counterfeit.
- `i2c_worker.c` — the bus. Address sweep, register reads at 8- and 16-bit indices, the
  electrical checks behind the wiring screen. Acquires and releases the external I²C handle on
  every path.
- `onewire_worker.c` — 1-Wire ROM search, family decode and a DS18x20 temperature conversion.
- `live_*.c` — one self-contained test per part, each identifying the chip before writing
  anything to it and parking only what it changed.
- `live_plugin.c` — loading tests from the SD card, with the descriptor treated as untrusted.
- `report.c`, `i2c_notify.c`, `i2c_settings.c` — report text, the melody/LED/vibration feedback,
  and the settings that switch each off.

The parts I would point a reviewer at: the app must never call a genuine part a fake, so the
verdict logic is deliberately reluctant, and any test that writes to a part it has not been able
to identify warns on screen for three seconds first, because several sensor addresses overlap
with GPIO expanders where a configuration byte would drive somebody's pins.


# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
