### PR TITLE
Update Hotspot Arcade to 1.8

### DIFF
--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: b2792aae35444503943ba63a2725bad14fbf5900
+    commit_sha: ee33885adf0ec743899436358a6d61fbf302a792
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO

--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: ee33885adf0ec743899436358a6d61fbf302a792
+    commit_sha: 50b1bad2f0b18c5c0c1a271b73be8156080bfdc7
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO


### PR DESCRIPTION
Bumps Hotspot Arcade to 1.8 (pins commit ee33885 — the v1.8.0 release commit). The description, changelog, and screenshots resolve from that commit.

Since 1.7: four new party games — Fill the Blank, Werewolf, Spyfall, and Draw a Monster (contributed by genkigenki) — for twenty in all. Also fixes a freeze under load on the official ESP32-S2 board (its spare PSRAM is now used, so memory stays healthy all session), reconnecting keeps your score even when the phone changes its Wi-Fi address, and the Flipper dashboard shows the board's free memory. Firmware v20.

Release: https://github.com/tarikbc/hotspot-arcade/releases/tag/v1.8.0