### PR TITLE
Bump Seader to v4.2

### DIFF
--- a/applications/NFC/seader/manifest.yml
+++ b/applications/NFC/seader/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/bettse/seader.git
-    commit_sha: bf10c834ebf90444c916887ecbb714a1e615600b
+    commit_sha: f6e123fadea46ddf5085f38c18ca6f2a950d3ae2
 short_description: "Allows for reading credential from HID iClass, iClass SE, Desfire EV1/EV2, and Seos"
 description: |
   Allows for reading credential from HID iClass, iClass SE, MFC SE, Desfire EV1/EV2, and Seos. Credentials can be saved in an agnostic format, or as various Flipper formats (Prox, MFC, iClass, iClass SR), depending on the original type.


### PR DESCRIPTION
# Application Submission

Bump Seader to v4.2. Notable changes since v4.1:
- UART/CCID rework: immutable TX frames published through the UART queue, safer compaction of consumed RX frames, control frames built off a scratch buffer, and removal of the RX chunk delay
- T=1 chained-response allocation failures are now surfaced instead of silently truncating
- Further RAM reductions: lazy allocation of NFC host objects, reuse of HF/picopass transmit buffers, and freeing inactive views during config and HF reads
- picopass fixes: CRC trimmed from the receiving buffer, and virtual replay reads bounded to the saved SIO
- SAM diagnostics: failed key probes surfaced on the main screen, faster parsing of HF nfcSend responses
- Fixed unaligned `dwLength` loads in CCID and added a calloc size-overflow guard
- HF read failure context is reset between reads, and prompt state is held until teardown completes
- Stabilized HF/SAM reads and reduced memory pressure when running alongside qFlipper (Thanks @cindersocket)

# Extra Requirements

Requires addon: UART to mini-SIM adapter and HID SAM (unchanged from prior releases).

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/NFC/seader/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out):

- [x] Partially AI assisted (clarify below which code was AI assisted and briefly explain what it does).

Portions of the app code (UART/CCID frame handling, memory footprint reductions, and HF buffer reuse) were developed with AI assistance and reviewed by the maintainer. The catalog manifest change itself is not AI-generated.

# Reviewer Checklist (Don't fill this out!)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
