### PR TITLE
Add UHF Expansion 1.0

### DIFF
--- a/applications/GPIO/uhf_expansion/manifest.yml
+++ b/applications/GPIO/uhf_expansion/manifest.yml
@@ -1,0 +1,14 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/mtoolstec/fz-uhf-expansion.git
+    commit_sha: dd0a8286d5a76431883c039c31678f43b7109e9b
+short_description: UHF RFID inventory reader over GPIO UART
+description: "@CATALOG.md"
+changelog: "@CHANGELOG.md"
+screenshots:
+  - images/01.png
+  - images/05.png
+  - images/04.png
+  - images/03.png
+  - images/02.png


### PR DESCRIPTION
# Application Submission

- Adds UHF Expansion 1.0, a GPIO UART application for EPC Gen2 UHF RFID inventory.
- Provides Radar, counter, and EPC list views with unique-tag and read-rate metrics.
- Shows reader temperature and output power telemetry and supports CSV export.
- Includes startup recovery and continuous-inventory renewal for compatible reader modules.

# Extra Requirements

- Requires an MTools Tec UHF Expansion or compatible UCM601 UHF reader module.
- Uses Flipper Zero GPIO UART pins 13/14 and reset pin 16 on supported expansion revisions.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out)

- Partially AI assisted - AI assistance was used to review and modify UART response parsing, EPC compatibility, reader temperature and power queries, Radar metrics and UI symbols, release cleanup, and catalog metadata. The existing application architecture and hardware integration were retained, and the resulting build was validated and tested on a connected Flipper Zero.

# Reviewer Checklist (Don't fill this out, and don't remove it from the template)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
