### PR TITLE
Update htw_ac_remote to v1.2

### DIFF
--- a/applications/Infrared/htw_ac_remote/manifest.yml
+++ b/applications/Infrared/htw_ac_remote/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/sokogen/flipperzero-htw-ac-remote.git
-    commit_sha: 9f66b7f3dc34df21baeccb95762da6e3547ed4c5
+    commit_sha: a4680f9967cbfd0a29142b64bab77a9c803e0584
 short_description: "HTW air conditioner IR remote control"
 description: "@./README_CATALOG.md"
 changelog: "@./CHANGELOG.md"


### PR DESCRIPTION
## Update: HTW AC Remote v1.2

Bumps `commit_sha` to the v1.2 release.

### Changelog
- Mode/Fan: replaced cycle-on-OK carousel with a dropdown list overlay (browse freely, confirm to send, Back to cancel)
- Setup screen: more compact layout, now shows app version at the bottom
- Main screen: normalized +/- icon stroke weight, rebalanced vertical spacing
- Removed unused state-cycling API and empty icon assets config

Screenshots updated to match, landscape orientation as required.

### Repository
https://github.com/sokogen/flipperzero-htw-ac-remote/releases/tag/v1.2