### PR TITLE
Specter 2.7

### DIFF
--- a/applications/NFC/specter/manifest.yml
+++ b/applications/NFC/specter/manifest.yml
@@ -3,12 +3,6 @@ sourcecode:
   location:
     origin: https://github.com/at0m-b0mb/Specter-FlipperZero.git
     commit_sha: 212d6eacf9265063308967010394b8cbd205f9f3
-    subdir:
-name: Specter
-id: specter
-category: NFC
-version: "2.7"
-author: at0m-b0mb
 short_description: Passively sense active 13.56 MHz NFC readers and skimmers with the onboard NFC chip. No extra hardware, never transmits.
 description: |
   Specter turns your Flipper Zero into a pocket counter-surveillance bug-sweep for active 13.56 MHz NFC readers. It **passively listens** for the RF field that a powered-on reader constantly emits — a hidden card skimmer slipped into a payment terminal, a covert reader behind a door panel, a rogue logger taped under a desk — then tells you where it is, what kind of thing it is, whether the room is clean, and, left on watch, the moment one appears while you are away.
@@ -54,7 +48,6 @@ changelog: |
   - OK cancels a noise-floor scan in progress, and settings writes are deferred off the hot path.
 
   Full version history: [docs/changelog.md](https://github.com/at0m-b0mb/Specter-FlipperZero/blob/main/docs/changelog.md)
-icon: icons/specter_10px.png
 screenshots:
   - screenshots/ss0.png
   - screenshots/ss1.png
@@ -62,5 +55,3 @@ screenshots:
   - screenshots/ss0_2.png
   - screenshots/ss1_2.png
   - screenshots/ss2_2.png
-targets:
-  - f7

--- a/applications/NFC/specter/manifest.yml
+++ b/applications/NFC/specter/manifest.yml
@@ -1,0 +1,66 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/at0m-b0mb/Specter-FlipperZero.git
+    commit_sha: 212d6eacf9265063308967010394b8cbd205f9f3
+    subdir:
+name: Specter
+id: specter
+category: NFC
+version: "2.7"
+author: at0m-b0mb
+short_description: Passively sense active 13.56 MHz NFC readers and skimmers with the onboard NFC chip. No extra hardware, never transmits.
+description: |
+  Specter turns your Flipper Zero into a pocket counter-surveillance bug-sweep for active 13.56 MHz NFC readers. It **passively listens** for the RF field that a powered-on reader constantly emits — a hidden card skimmer slipped into a payment terminal, a covert reader behind a door panel, a rogue logger taped under a desk — then tells you where it is, what kind of thing it is, whether the room is clean, and, left on watch, the moment one appears while you are away.
+
+  **No extra hardware. It never transmits.** Specter uses the Flipper's onboard NFC chip in field-detect mode, so there is nothing to buy and nothing to plug in.
+
+  ## What it does
+
+  Specter answers four questions, each on its own screen:
+
+  - **Sweep — where is it?** An analog-style EMF gauge whose needle rides the field strength in real time, with a peak-hold marker and a hot zone. When a reader's carrier is sensed the screen frames itself in an alarm border and shows a proximity readout (FAINT / NEAR / CLOSE / STRONG). Optional geiger clicks speed up as the field gets stronger, so you can home in on the source without looking at the screen.
+  - **Fingerprint — what is it?** Classifies the reader's polling cadence as CONTINUOUS, POLLING, or INTERMITTENT with a confidence readout and a logic-analyzer pulse train.
+  - **Site Survey — is the room clean?** Sweeps over time and returns a CLEAN / TRACE / ACTIVE verdict.
+  - **Watch — did one show up while I was away?** An unattended monitor that wakes the screen and logs the moment a reader appears, with a running clock, contact count, and peak field.
+
+  ## Logbook
+
+  Every detection can be saved to the SD card, RTC-timestamped, as both a human-readable logbook.txt and a spreadsheet-friendly logbook.csv.
+
+  ## How it works
+
+  Specter reads the external-field-detected bit on the onboard ST25R3916 NFC chip and samples it continuously, condensing it into a field-strength percentage and timing the carrier's on/off cadence. It is **listen-only** — it detects the reader's field but never emits one of its own.
+
+  ## Limitations
+
+  - **13.56 MHz (HF) only.** Specter cannot sense 125 kHz (LF) readers — the onboard field-detect path exists only on the HF radio.
+  - It detects an active, powered reader's field. A passive tag or a reader that is switched off produces no field to detect.
+changelog: |
+  ## 2.7
+
+  - Watch Mode alarm is calmer: the READER PRESENT band no longer strobes at 5 Hz — it is solidly inverted, with a small marker pulsing at about 1 Hz as a "this is live" cue.
+  - READER PRESENT now releases faster after a reader leaves. The hold time derives from the reader's own measured polling period (about 2.5 cycles, clamped to 600–1500 ms) instead of a fixed 1.5 s.
+  - Releases now ship two builds: one for official firmware (API 87) and one for the newer API 88 line (Unleashed / RogueMaster / Momentum), because a compiled app targets a single API version.
+
+  ## 2.6
+
+  - Fixed a divider line clipping the NOISE FLOOR text during a noise-floor scan, and the ACTIVE READER alarm text losing its bottom pixel row.
+  - Added a static layout checker that fails the build if any two drawing primitives overlap on screen.
+
+  ## 2.5
+
+  - Fixed an input lock-up that could force a Flipper reboot when keys were pressed during a noise-floor scan. The sampling worker now yields to the scheduler and runs below the UI.
+  - OK cancels a noise-floor scan in progress, and settings writes are deferred off the hot path.
+
+  Full version history: [docs/changelog.md](https://github.com/at0m-b0mb/Specter-FlipperZero/blob/main/docs/changelog.md)
+icon: icons/specter_10px.png
+screenshots:
+  - screenshots/ss0.png
+  - screenshots/ss1.png
+  - screenshots/ss2.png
+  - screenshots/ss0_2.png
+  - screenshots/ss1_2.png
+  - screenshots/ss2_2.png
+targets:
+  - f7


### PR DESCRIPTION
# Application Submission

Specter is a passive, receive-only NFC counter-surveillance "bug sweep" for Flipper Zero. Using the onboard NFC chip (ST25R3916) in field-detect mode, it senses the 13.56 MHz RF field that an active reader or skimmer emits — a hidden POS skimmer, a covert door reader, a rogue logger — and helps you:

- **Sweep** — locate the source with an analog-style EMF gauge, a proximity readout (FAINT/NEAR/CLOSE/STRONG), and optional geiger clicks that speed up with field strength.
- **Fingerprint** — classify the reader's polling cadence (CONTINUOUS / POLLING / INTERMITTENT) with a confidence readout and a logic-analyzer pulse train.
- **Site Survey** — judge whether a room is CLEAN / TRACE / ACTIVE over time.
- **Watch** — stand guard unattended and log the moment a reader appears.

Detections can be saved to a timestamped SD logbook (txt + CSV). It is listen-only and never transmits.

This is the initial catalog submission, at version 2.7.

# Extra Requirements

None. No extra hardware — it uses the Flipper's onboard NFC field-detect capability. 13.56 MHz (HF) only; it cannot sense 125 kHz (LF) readers.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/NFC/specter/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out)

- Partially AI assisted - clarify below which parts were AI assisted and briefly explain what they do.

The design, feature set, and direction are mine, and I own, license (MIT), and have reviewed all of the code. Claude (Anthropic) assisted with implementation and refactoring during development — for example the onboard field-detect sampling worker (`helpers/field_detector.c`) and the pure, host-tested logic layers it feeds: the emitter classifier, the site-survey verdict, the Watch presence debouncing, and the meter scaling. All AI-assisted code was reviewed, covered by the host test suites, and verified on real Flipper Zero hardware before release.
