### PR TITLE
[Tools] Guitar Chords 1.0

### DIFF
--- a/applications/Tools/guitar_chords/manifest.yml
+++ b/applications/Tools/guitar_chords/manifest.yml
@@ -1,0 +1,12 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/NoodleNugget-com/flipper-guitar-chords.git
+    commit_sha: e98240c2a1049eb69016d8e09c42b55e5ac29035
+description: "@docs/description.md"
+changelog: "@changelog.md"
+screenshots:
+  - screenshots/01-chord.png
+  - screenshots/02-voicing.png
+  - screenshots/03-practice.png
+  - screenshots/04-progressions.png


### PR DESCRIPTION
# Application Submission

Guitar Chords is a chord reference and practice metronome for Flipper Zero.

Browse by root note and read the fretboard diagram for any chord: muted and open
strings, finger numbers, and a solid bar where a barre is needed. The library ships
281 voicings across 99 chord names covering all twelve roots, with major, minor, 7,
m7, maj7, sus2, sus4 and power chord shapes. Most chords carry two or three
voicings; Left and Right cycle them, Up and Down move to the next chord in the same
root's list.

Practice mode plays one of 14 built-in progressions, from two-chord transition
drills to four-chord standards like I-V-vi-IV and a twelve bar blues. Each chord
lasts one bar of four beats, with a metronome click on every beat and a higher click
plus vibro on the chord change. Tempo is adjustable from 40 to 200 bpm.

Both the chord library and the progression list are plain text files on the SD card,
seeded on first launch, so users can add their own chords and progressions without
rebuilding the app.

This is the initial release (v1.0).

# Extra Requirements

None. No additional hardware or software is required.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out)

- Fully AI generated - explain what all the generated code does in moderate detail.

The application was generated with AI (Claude), then built, linted and run on real
hardware before submission. What each part does:

**guitar_chords.c** — app lifecycle and navigation. Allocates a ViewDispatcher with
six views (splash, root menu, chord menu, chord diagram, progression menu, practice
screen) and routes Back through a navigation callback that walks back up that tree
and exits from the root. The splash waits for a key press. The root menu lists the
root notes present in the library, plus a Practice entry that uses a sentinel index
kept clear of the root indices. Practice mode is driven here: a periodic FuriTimer
posts a beat event to the ViewDispatcher custom event queue rather than touching
views or the notification service from the timer thread, and the handler advances
the chord every four beats and fires a NotificationSequence for the click and vibro.

**chord_db.c/.h** — the chord library. A Chord holds a name, root, quality, six fret
offsets (-1 muted, 0 open), a base fret and six finger numbers. Records are parsed
from a pipe-delimited line, NAME|FRETS|BASE_FRET|FINGERS; the leading letter plus an
optional sharp or flat becomes the root used for menu grouping. Frets outside a
four-fret window are slid back into range so absolute fret numbers still render.
Storage is a growable array. Queries return the distinct roots in chromatic order,
the distinct chord names for a root, and the indices of every voicing sharing a
name. The library loads from SD and falls back to a compiled-in table if the file is
missing or unparseable.

**chord_view.c/.h** — the fretboard renderer. Draws six strings and four fret spaces,
a thick nut at fret one or an "Nfr" label above it otherwise, x and o markers above
muted and open strings, dots for fretted notes, finger numbers below, and a rounded
bar wherever one finger covers two or more strings on the same fret. When a chord has
more than one voicing it also draws an "n/m" counter and filled triangles at both
edges. Input maps Left/Right to voicing cycling and Up/Down to chord stepping via
callbacks, letting Back fall through to the dispatcher.

**song_db.c/.h** — progressions. Parses NAME|CHORDS|BPM records, where CHORDS is a
comma-separated list of two to eight chord names, into a growable array, with the
same SD-with-compiled-in-fallback loading as the chord library.

**practice_view.c/.h** — the practice screen. Shows the current chord name, tempo, a
play/pause glyph, the chord diagram (reusing the renderer above with finger numbers
suppressed to free the bottom band) and a row of dots marking position in the
progression. A chord name absent from the library renders as "not in library" rather
than failing. Input is reported through a single action callback.

**assets/chords.csv and the compiled-in chord table** — generated from movable shape
families (E, A and D shape barres) transposed to all twelve roots, combined with
curated open positions. Every entry was then verified programmatically by computing
the pitch class of each fretted note from standard tuning and checking the resulting
set against the expected chord tones for that name, that the root is in the bass,
and that the shape fits the four-fret display window.

**icon.png** — a 10x10 1-bit guitar silhouette.

Build configuration note: application.fam sets sources=["*.c"], because the fbt
default glob "*.c*" also matches assets/chords.csv and passes it to the linker.

Verified with ufbt against firmware 1.4.3 (target f7, API 87.1): builds clean under
-Wall -Wextra -Werror, passes ufbt lint, and the bundle validates with tools/bundle.py.
The screenshots are unmodified qFlipper captures of the app running on a Flipper Zero.
