### PR TITLE
Add Handpan Chords 1.0

### DIFF
--- a/applications/Media/handpan_chords/manifest.yml
+++ b/applications/Media/handpan_chords/manifest.yml
@@ -1,0 +1,13 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/NoodleNugget-com/handpan_chords.git
+    commit_sha: 42be5d572eb12a2d18e885c517837a564ee6c0e8
+screenshots:
+  - screenshots/Screenshot-20260821-161722.png
+  - screenshots/Screenshot-20260821-161804.png
+  - screenshots/Screenshot-20260821-161701.png
+  - screenshots/Screenshot-20260821-161612.png
+short_description: See which pads to strike for any chord on your handpan
+description: "@catalog-description.md"
+changelog: "@changelog.md"


### PR DESCRIPTION
# Application Submission

Handpan Chords is a chord reference and practice tool for handpans.

Nine 9-note handpans are built in (D Kurd, D Celtic Minor, D Sabye, C# Amara,
E La Sirena, B Kurd, A Kurd, F Low Pygmy, C Major). Pick a drum and the app
shows every chord it can play on a diagram of the shell, with the pads you need
to strike filled in.

Nothing is hardcoded per drum. Each handpan is stored only as MIDI note numbers,
and chords are derived at runtime by testing every chord formula against the
drum's pitch classes, so only genuinely playable chords appear (41 on D Kurd 9,
12 on F Low Pygmy 9). A chord depth setting filters to triads, plus sixths and
sevenths, or everything.

Practice mode has 14 melodic phrases stored as scale degrees rather than
absolute notes, so each one transposes to whichever drum is selected and is
offered only when that drum has every note it needs. Phrases play back one
strike at a time at three speeds, or can be stepped through by hand. Some use
the ding as a bass voice and some call for two pads struck together.

Favourites are saved to the SD card.

This is a first submission, so there is no previous version to diff against.

# Extra Requirements

None. The app runs on a stock Flipper Zero with no extra hardware or software.
It uses only the gui and storage services and plain ViewPort input, so it builds
unmodified against stock, Momentum and Unleashed firmware. Owning a handpan is
obviously useful but is not needed to browse the app.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out)

- Fully AI generated - explain what all the generated code does in moderate detail.

All of the C source was written by Claude (Anthropic) from a detailed
specification I wrote: I chose the architecture, the tuning data for all nine
drums, the chord formula table, the screen layouts and pixel coordinates, and
the rule that chords must be derived rather than listed. The AI wrote the
implementation and I directed and reviewed it throughout.

The screenshots are my own, taken with the qFlipper screenshot feature and not
altered or generated in any way. The 10x10 app icon was generated as a plain
two-colour pixel grid.

What the code does, by file:

- `application.fam` - build manifest. Entry point `handpan_app`, category Media,
  4 KB stack, requires gui and storage.
- `handpan.h` - shared types and declarations: the drum, chord, formula,
  practice step and favourite structs, plus the pattern authoring macros.
- `scales.c` - all the musical data and derivation. Holds the nine drums as MIDI
  note arrays, the 18 chord formulas, sharp and flat note-name tables, and the
  14 practice phrases. `hp_build_chords()` reduces the drum to a 12-bit
  pitch-class mask, walks root notes starting from the ding so the tonic chord
  comes first, and accepts a chord only when every one of its tones is present,
  recording which physical pads carry those notes. `hp_pattern_steps()` voices a
  practice phrase onto specific pads using a small shortest-path over
  (step, pad) that minimises how far the hands travel, which avoids stranding a
  descending line in the wrong octave; the ding is excluded from that path
  because it is the bass voice rather than part of the tune.
- `favorites.c` - SD card persistence at
  `/ext/apps_data/handpan/favorites.txt`. Parses with `strtol` and validates
  every field against current table bounds, skipping malformed lines so a
  corrupt file cannot crash the app.
- `handpan.c` - all UI. A plain ViewPort plus FuriMessageQueue input loop with a
  hand-rolled screen state machine (no ViewDispatcher or Submenu, so the code
  does not break across firmware forks). Contains the launch animation, the
  shared scrolling list widget, the pan diagram drawing, the chord and
  play-along screens, input handling, and the mutex-guarded draw callback.

The derivation logic was tested by compiling `scales.c` natively on the host and
checking the output across all nine drums: 353 chords, no buffer overruns under
ASan and UBSan, all malformed favourites-file inputs rejected, and every
practice phrase checked for octave leaps and repeated strikes. The app has also
been run on hardware, which is where the screenshots come from.
