### PR TITLE
Update TPMS Bridge to version 1.1

### DIFF
--- a/applications/Sub-GHz/tpms_bridge/manifest.yml
+++ b/applications/Sub-GHz/tpms_bridge/manifest.yml
@@ -2,13 +2,13 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/VishovVladimir/flipper-zero-tpms.git
-    commit_sha: a93a5daf541839301aeaddbe8efa855d14e89c3c
+    commit_sha: db59a88d3abc5608ec2a16d07c4d600415f1f950
     subdir: flipper/tpms_bridge
 
 description: "@README.md"
 changelog: "@changelog.md"
 screenshots:
-  - screenshots/4.png
-  - screenshots/3.png
-  - screenshots/2.png
   - screenshots/1.png
+  - screenshots/2.png
+  - screenshots/3.png
+  - screenshots/4.png

--- a/applications/Sub-GHz/tpms_bridge/manifest.yml
+++ b/applications/Sub-GHz/tpms_bridge/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/VishovVladimir/flipper-zero-tpms.git
-    commit_sha: db59a88d3abc5608ec2a16d07c4d600415f1f950
+    commit_sha: f4064c1f5331c7a58b1783edeae0fe76ddc92816
     subdir: flipper/tpms_bridge
 
 description: "@README.md"


### PR DESCRIPTION
# Application Submission

- TPMS Bridge now decodes 39 protocols at once instead of just the Renault group sensor from v1.0, covering OEM sensors used by: Renault, Dacia, Citroen, Peugeot,   
    Fiat, Mitsubishi, Ford, Toyota, Lexus, Hyundai, Kia, Honda, BMW, Mini, Mercedes, Porsche, Audi, Abarth, Mazda, Chrysler, Jeep, Dodge, Opel, Saab, Vauxhall,        
    Chevrolet, GM, Subaru, Infiniti, Nissan and Aston Martin, plus the multi-brand HUF, Beru, Continental and Sensata units, motorcycle sensors, and a dozen           
    aftermarket/truck units (Jansite TY02S, Jansite Solar, Jansite TY588, Jansite TY468, iMars T240, Airpuxem, Sefis M3, Careud, EezTire, TST-507, TyreGuard 400, Gear 
    Hive, EGQ Q85 and unbranded solar truck sensors). A reading is labelled with whichever protocol's checksum it satisfies.                                           
  - Band (433.92/315 MHz) and modulation (FSK/OOK) selection moved onto the Up/Down keys, and a fifth "scan" setting steps through all four combinations in turn (4s   
    each); the header shows AUTO- plus whichever setting is currently on air while it does.


# Extra Requirements 

- None beyond the Flipper Zero itself. The app configures the CC1101 radio directly; no other hardware or software is needed.


# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out)

Keep the ONE option below that matches your submission and DELETE the other two.

- Fully AI generated - explain what all the generated code does in moderate detail.

- The application — radio configuration, all 39 protocol decoders, the on-device list/detail screens, the USB CLI streaming command, and this README/changelog — was   
  generated with Claude (Anthropic), each decoder validated against reference frame data for its protocol. Only the Renault-group decoder has been verified against    
  real sensor hardware (bench and moving car); the other 38 protocols are verified against reference output only, not against physical sensors of those makes. 

# Reviewer Checklist (Don't fill this out, and don't remove it from the template)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
