### PR TITLE
Add BioVault 0.1

### DIFF
--- a/applications/NFC/biovault/manifest.yml
+++ b/applications/NFC/biovault/manifest.yml
@@ -1,0 +1,16 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/flamebarke/biovault-flipper.git
+    commit_sha: 647550ecef3a91a9f227b69c42c10b3f24d544ce
+description: "@.catalog/README.md"
+changelog: "@changelog.md"
+screenshots:
+  - screenshots/1_vault.png
+  - screenshots/2_pin_entry.png
+  - screenshots/3_main_menu.png
+  - screenshots/4_entry_actions.png
+  - screenshots/5_secret_keyboard.png
+  - screenshots/6_settings.png
+  - screenshots/7_settings_pin.png
+  - screenshots/8_diagnostics.png

--- a/applications/NFC/biovault/manifest.yml
+++ b/applications/NFC/biovault/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/flamebarke/biovault-flipper.git
-    commit_sha: 647550ecef3a91a9f227b69c42c10b3f24d544ce
+    commit_sha: 98be332a51f6fd4e321db84199767193ec0d2c42
 description: "@.catalog/README.md"
 changelog: "@changelog.md"
 screenshots:


### PR DESCRIPTION
# Application Submission

BioVault v0.1 - a password vault stored AES-256-GCM encrypted on an NFC implant (Dangerous Things xSIID / NTAG I2C Plus 2K), unlockable only by the Flipper that owns it. The data key is wrapped by the device-unique key in the STM32WB55 secure enclave, so the implant alone yields ciphertext and the Flipper alone holds nothing to decrypt.

This is a Flipper-native reimplementation of my BioVault project for the Proxmark3 (https://github.com/flamebarke/biovault - Python + Lua, whose hf_i2c_plus_2k utils are upstreamed in the Proxmark3 Iceman fork). The concept, on-tag layout (vault in Sector 1, Sector 0 left free for NDEF), and security model predate this port; the Flipper version replaces the password-based OpenSSL encryption with a key held in the device's secure enclave.

Features:
- Browse / add / edit / remove credentials and notes on-device; secrets up to 255 chars (fits a 24-word seed phrase); vault is heatshrink-compressed before encryption to maximize the tag's 1 KB Sector 1.
- Type credentials into a computer over USB-HID.
- Optional chip-side password protection of Sector 1 (PWD_AUTH/PACK derived from the enclave key + tag UID, never stored; fully reversible, never touches one-way locks).
- Optional 6-digit vault PIN: PIN is stretched (PBKDF2 + an enclave-iterated AES chain, ~3 s/guess, not offloadable) into key material that wraps the vault key - no verifier stored, nothing to patch out.
- `biovault` USB serial CLI mirroring every on-device command.
- Crypto self-tests (GCM KAT, enclave round-trip, KDF KAT) shown on a Diagnostics screen.

Note for reviewers re: enclave usage - the app calls `furi_hal_crypto_enclave_ensure_key(FURI_HAL_CRYPTO_ENCLAVE_UNIQUE_KEY_SLOT)`, the same call and slot the stock U2F app uses (`applications/main/u2f/u2f_data.c`), i.e. the device-unique key, not the shared factory keys.

# Extra Requirements

- An NTAG I2C Plus 2K tag (NXP NT3H2211) - e.g. the Dangerous Things xSIID implant. Without one the app runs but has nothing to load from or save to.
- No extra software; the optional CLI uses the standard USB serial console.

# Author Checklist

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure

- Fully AI generated

The C code in this submission was written with Claude Code (Anthropic). The project itself is a port of my pre-AI BioVault project for the Proxmark3 (https://github.com/flamebarke/biovault): the concept, the on-tag layout, and the security model are my original design. I made the architectural and security decisions and performed all hardware testing on a real Flipper and xSIID implant.

What the generated code does: 
- `bv_crypto.c` wraps `furi_hal_crypto` (enclave AES-CBC key-wrap of a random 256-bit data key, AES-256-GCM over the vault, the enclave-iterated key-stretch used by the PIN feature, and known-answer self-tests).
-  `bv_vault.c` implements the keystore file (v1 = enclave-wrapped data key, v2 = additionally PIN-wrapped) and the on-tag blob codec (compress-then-encrypt, versioned framing). 
- `bv_pin.c` is a vendored SHA-256/HMAC/PBKDF2 implementation (the firmware exposes no such primitives) feeding the enclave stretch. `bv_records.c` is the length-prefixed vault serializer.
- `biovault.c` holds the app scaffolding and UI scenes (incl. a 6-digit PIN entry view), the ISO14443-3A polling workers that read/write Sector 1 and provision the tag's PWD_AUTH/PACK, and the serial CLI. 
- `bv_text_input.c` is the firmware text-input keyboard vendored with an added symbols layer. 
- `bv_hid.c` types strings over USB-HID. 
- `bv_settings.c` persists app settings.

# Reviewer Checklist

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality