### PR TITLE
Update nfc_login to v1.1.3

### DIFF
--- a/applications/NFC/nfc_login/manifest.yml
+++ b/applications/NFC/nfc_login/manifest.yml
@@ -18,7 +18,7 @@ short_description: NFC based desktop login using USB HID or BLE HID
 
 sourcecode:
   location:
-    commit_sha: c265bafab7a3e402c74cb623a6198228297077cc
+    commit_sha: 52c9ad80b759493003477757472bd4971f717e3f 
     origin: https://github.com/Play2BReal/NFC-Login
   type: git
 

--- a/applications/NFC/nfc_login/manifest.yml
+++ b/applications/NFC/nfc_login/manifest.yml
@@ -1,11 +1,11 @@
-author: 'Play2BReal'
-category: 'NFC'
+sourcecode:
+  type: git
+  location:
+    commit_sha: 52c9ad80b759493003477757472bd4971f717e3f 
+    origin: https://github.com/Play2BReal/NFC-Login
 changelog: "@changelog.md"
 description: "@README.md"
-icon: 'icons/icon.png'
-id: 'nfc_login'
-name: 'NFC Login'
-
+short_description: "NFC based desktop login using USB HID or BLE HID"
 screenshots:
   - screenshots/ss0.png
   - screenshots/ss1.png
@@ -14,12 +14,3 @@ screenshots:
   - screenshots/ss4.png
   - screenshots/ss5.png
 
-short_description: NFC based desktop login using USB HID or BLE HID
-
-sourcecode:
-  location:
-    commit_sha: 52c9ad80b759493003477757472bd4971f717e3f 
-    origin: https://github.com/Play2BReal/NFC-Login
-  type: git
-
-version: 1.1.2


### PR DESCRIPTION
## What's changed
Bumps `commit_sha` to `52c9ad80b759493003477757472bd4971f717e3f`.
Adds Active Scan ON/OFF in Settings.
### Changelog
- Settings: Active Scan ON/OFF
  - ON (default): field stays on during Start Scan
  - OFF: OK pulses the field ~1s to read UID, then off until next OK
https://github.com/Play2BReal/NFC-Login
