### PR TITLE
Update Hotspot Arcade to 1.9.0

### DIFF
--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: 50b1bad2f0b18c5c0c1a271b73be8156080bfdc7
+    commit_sha: 3ae0fd2378f01ee092bfc07c3bd21ba8091cbb30
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO


### PR DESCRIPTION
Bumps `hotspot_arcade` to 1.9.0 (fap_version `1.9.0`, ESP firmware v22).

Release: https://github.com/tarikbc/hotspot-arcade/releases/tag/v1.9.0

**Scores now carry across the whole evening.** Games pay on very different scales, so a
ranking across them never meant much. At the end of any game you now gain a point for every
player you finished above, so a win in a six-player round counts for more than a win at a
two-player board, and every game contributes on the same footing however it scores inside.
Each game keeps its own scoring unchanged.

**The join page opens by itself again.** The access point was handing out an address but
never telling phones where to look up names, so phones concluded there was no internet and
never offered the portal. Entering the address by hand always worked, which is why it went
unnoticed.

**Holds up with several phones.** A busy session could exhaust the board and stop serving
pages until it was restarted, while spare memory on the board sat unused.

Also: a Reset Scores control, a leaderboard that ranks on the evening and fits one more
player, and fixes to renaming, reconnecting, and Battleship scoring.

Game count is unchanged at twenty, so the screenshots are unchanged.

Tested on the official ESP32-S2 dev board. Builds for all three supported boards.