### PR TITLE
ZeroMesh: update to 3.0

### DIFF
--- a/applications/GPIO/zeromesh/manifest.yml
+++ b/applications/GPIO/zeromesh/manifest.yml
@@ -2,16 +2,19 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/SAMS0N1TE/ZeroMesh.git
-    commit_sha: df0558610952e5e2ee406d6b2494cd2e08b83eec
+    commit_sha: 9846160439bf9736399d4706fc3777e6075920b5
 
-short_description: Meshtastic serial interface for Flipper Zero
+short_description: Meshtastic client with offline vector maps, over serial or Bluetooth
 
-description: "@README.md"
+description: "@docs/description.md"
 
 changelog: "@changelog.md"
 
 screenshots:
+  - docs/images/map.png
+  - docs/images/map_toolbar.png
   - docs/images/messages.png
   - docs/images/roster.png
   - docs/images/chat.png
+  - docs/images/stats.png
   - docs/images/settings.png

--- a/applications/GPIO/zeromesh/manifest.yml
+++ b/applications/GPIO/zeromesh/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/SAMS0N1TE/ZeroMesh.git
-    commit_sha: 9846160439bf9736399d4706fc3777e6075920b5
+    commit_sha: 2ed6ac6331ad7a5c4db0a3900d060fa0bae98f8a
 
 short_description: Meshtastic client with offline vector maps, over serial or Bluetooth
 

--- a/applications/GPIO/zeromesh/manifest.yml
+++ b/applications/GPIO/zeromesh/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/SAMS0N1TE/ZeroMesh.git
-    commit_sha: 2ed6ac6331ad7a5c4db0a3900d060fa0bae98f8a
+    commit_sha: 094dd0665540646e71298985a2c573c68a8b77d6
 
 short_description: Meshtastic client with offline vector maps, over serial or Bluetooth
 


### PR DESCRIPTION
# Application Submission

ZeroMesh 3.0, updating the existing GPIO entry from 2.1.

Since the last release:

- **Bluetooth LE transport** alongside the existing serial link, selectable in Settings. The Flipper radio can only act as a peripheral, so the node connects to the Flipper rather than the reverse, which needs a Meshtastic build carrying the ZeroMesh link module. Serial remains the default and works with stock node firmware.
- **Offline vector map** rendering Mapbox Vector Tiles from a PMTiles archive on the SD card, centred on a mesh node, with place and water labels, a scale bar, markers for nodes reporting a GPS position, and range and bearing to the selected node. Panning crosses tile boundaries and a dashed border marks where the archive ends. An on-map toolbar offers nearby place names, a label toggle, home, node cycling and zoom.
- **Node configuration** for the connected radio: LoRa region, modem preset, device role, GPS, a fixed position for a node with no GPS fix, and the primary channel key and position sharing. Channel and position settings are read back from the radio before being written so existing values are preserved.
- Node names decoded from NodeInfo and shown throughout, delivery reported from routing acknowledgements, and position or node info requestable from the roster.
- Settings and map data moved to the app data directory. Both readers fall back to the previous location so existing installs keep working.

# Extra Requirements

A Meshtastic node connected to the GPIO UART (node TX to Flipper RX, node RX to Flipper TX, common ground). Bluetooth LE additionally requires a Meshtastic build carrying the ZeroMesh link module; serial works with stock node firmware.

Map data is optional. Without an archive the Map page still opens and reports it, and every other page works normally. Archives are built from OpenStreetMap vector tiles with tooling included in the repository.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out)

- Partially AI assisted - clarify below which parts were AI assisted and briefly explain what they do.

The 3.0 feature work was written with AI assistance under my direction and tested by me on hardware. That covers the Bluetooth LE GATT transport and its framing, the map page (PMTiles archive reader including leaf directory support, the vector tile renderer integration, label placement, and the node overlay).

# Reviewer Checklist (Don't fill this out, and don't remove it from the template)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
