### PR TITLE
Add SigRoam 0.4 to GPIO

### DIFF
--- a/applications/GPIO/sigroam/manifest.yml
+++ b/applications/GPIO/sigroam/manifest.yml
@@ -1,0 +1,134 @@
+# Flipper Apps Catalog submission manifest for SigRoam.
+#
+# Destination in flipperdevices/flipper-application-catalog:
+#   applications/GPIO/sigroam/manifest.yml
+# (path = applications / <category> / <appid> / manifest.yml, per documentation/Manifest.md)
+#
+# Fields deliberately NOT repeated here because application.fam already carries them --
+# the Catalog docs recommend specifying as many fields as possible in application.fam and
+# not in manifest.yml, to avoid duplication:
+#   name              <- name="SigRoam"
+#   id                <- appid="sigroam"
+#   category          <- fap_category="GPIO"
+#   version           <- fap_version="0.1"
+#   short_description <- fap_description="Wi-Fi survey companion for external ESP32 scanners"
+#   author            <- fap_author="PINGEQUA_Lab"
+#   icon              <- fap_icon="icons/sigroam.png"  (verified 10x10, bit_depth=1, 96 B)
+#
+# description and changelog are written inline rather than as "@README.md" / "@CHANGELOG.md"
+# on purpose. The Catalog renders only a subset of Markdown -- headers of levels 1-2, bold
+# and italic, lists, and links (documentation/Manifest.md, "Markdown support"). README.md
+# uses centered HTML, tables, images and fenced code blocks, and CHANGELOG.md uses level-3
+# headers; none of those are in the subset, so pointing at those files would render badly on
+# the app page. Everything below stays inside the supported subset.
+
+# commit_sha is pinned to the commit the v0.1 tag points at -- the exact snapshot the
+# published release was built from -- not to whatever main happens to be at submission time.
+# The Catalog takes a sha precisely so a submission is reproducible; later commits on main
+# (documentation fixes and the like) must not silently change what was reviewed.
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/pingequalab/sigroam-wardriving.git
+    commit_sha: 2269fe81cb20eedb9dd2c81f9a61b57654eaa0b0
+
+screenshots:
+  - screenshots/menu.png
+  - screenshots/dashboard.png
+  - screenshots/about.png
+  - screenshots/settings.png
+
+description: |
+  SigRoam turns a Flipper Zero into the control head for an external ESP32
+  Marauder Wi-Fi scanner. It starts and stops scans over the GPIO serial port,
+  shows AP, BLE and GPS counts live, and exposes the raw serial stream when the
+  numbers look wrong.
+
+  The Flipper has no Wi-Fi radio and does not scan by itself. The scanner board
+  does the scanning and the logging; SigRoam gives you control and live
+  visibility over the session.
+
+  ## Receive-only by design
+
+  SigRoam never transmits attack traffic. The following are permanently out of
+  scope -- a product rule, not a missing feature:
+
+  - deauthentication and disassociation frames
+  - WPA handshake capture
+  - evil twin, karma, and rogue AP
+  - beacon spam and BLE spam
+  - password cracking of any kind
+
+  The app only parses what the scanner prints.
+
+  ## What you get
+
+  - **Dashboard** with four tabs: live counters, parsed record stream, GPS
+    status, and session diagnostics. OK on the Dash tab starts and stops the
+    scan.
+  - **Probe firmware** sends an info request and reports what answered, so
+    "nothing connected" is distinguishable from "connected but not Marauder".
+  - **Raw log** shows the unparsed serial lines, including anything the parser
+    did not recognise.
+  - **Settings** for baud rate (six choices, default 115200), source codec,
+    sound, vibro, backlight, stealth and debug rows, persisted across restarts.
+  - **Unique-BSSID estimate** from a 4 KB Bloom filter, session-scoped and
+    RAM-only, as a progress indicator rather than a record of what you
+    collected.
+
+  ## Hardware and setup
+
+  Requires an ESP32 board running
+  [ESP32 Marauder](https://github.com/justcallmekoko/ESP32Marauder) firmware on
+  the GPIO header. Any Marauder-compatible board works; the reference board is
+  [Scout Lite](https://github.com/pingequalab/scout-lite).
+
+  Two things must be right or the app cannot open the port, and it tells you so
+  on screen rather than failing silently:
+
+  - **Log Device must be Off** in Settings, System. Pins 13 and 14 are shared
+    with the firmware serial log.
+  - **5V on pin 1 comes from the OTG boost converter**, not a permanent rail.
+    While USB is plugged in the firmware defers OTG, so the scanner may have no
+    power until USB is unplugged and the app restarted.
+
+  Do not power the scanner from pin 9. It is limited to 150 mA and a
+  5 GHz-capable ESP32 exceeds that on transmit peaks.
+
+  ## Where the data goes
+
+  SigRoam does not write survey data to the Flipper SD card; it persists only
+  your settings. Marauder writes its own CSV to the scanner board SD card, and
+  that file is what you upload to [WiGLE](https://wigle.net/).
+
+changelog: |
+  ## 0.1
+
+  First public release. Wi-Fi survey front-end for the Flipper Zero driving an
+  external ESP32 Marauder scanner over the GPIO serial port.
+
+  Added:
+
+  - Dashboard with four tabs -- live counters, parsed record stream, GPS status,
+    and session diagnostics. OK on the Dash tab starts and stops the scan, and
+    the scan keeps running when you leave the page with Back.
+  - Firmware probe that reports what answered an info request, distinguishing
+    "nothing connected" from "connected but not Marauder".
+  - Raw log view of unparsed serial lines, so a malformed feed is inspectable
+    rather than invisible.
+  - Settings for baud rate, source codec, sound, vibro, backlight, stealth and
+    debug rows, persisted across restarts.
+  - Unique-BSSID estimate from a 4 KB Bloom filter, session-scoped and RAM-only.
+  - GPIO serial handling with an OTG power gate, physical-state verification
+    before opening the port, and detection of the Log Device conflict on pins 13
+    and 14 -- each reported on screen instead of failing silently.
+  - QR code on the About page linking to the source repository.
+
+  Notes:
+
+  - Receive-only by design. No deauthentication, handshake capture, evil twin,
+    karma, beacon or BLE spam, or password cracking -- permanently out of scope.
+  - Survey data is not written to the Flipper SD card. Logging is the scanner's
+    job; the Flipper provides control and live visibility.
+  - Builds against Official and Momentum firmware from the same source using
+    only the common Flipper API.

--- a/applications/GPIO/sigroam/manifest.yml
+++ b/applications/GPIO/sigroam/manifest.yml
@@ -10,7 +10,7 @@
 #   name              <- name="SigRoam"
 #   id                <- appid="sigroam"
 #   category          <- fap_category="GPIO"
-#   version           <- fap_version="0.1"
+#   version           <- fap_version="0.2"
 #   short_description <- fap_description="Wi-Fi survey companion for external ESP32 scanners"
 #   author            <- fap_author="PINGEQUA_Lab"
 #   icon              <- fap_icon="icons/sigroam.png"  (verified 10x10, bit_depth=1, 96 B)
@@ -22,7 +22,7 @@
 # headers; none of those are in the subset, so pointing at those files would render badly on
 # the app page. Everything below stays inside the supported subset.
 
-# commit_sha is pinned to the commit the v0.1 tag points at -- the exact snapshot the
+# commit_sha is pinned to the commit the v0.2 tag points at -- the exact snapshot the
 # published release was built from -- not to whatever main happens to be at submission time.
 # The Catalog takes a sha precisely so a submission is reproducible; later commits on main
 # (documentation fixes and the like) must not silently change what was reviewed.
@@ -30,7 +30,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/pingequalab/sigroam-wardriving.git
-    commit_sha: 2269fe81cb20eedb9dd2c81f9a61b57654eaa0b0
+    commit_sha: 529257641a50f23e8b7f932715c7f7ab7794fd2f
 
 screenshots:
   - screenshots/menu.png
@@ -83,14 +83,15 @@ description: |
   the GPIO header. Any Marauder-compatible board works; the reference board is
   [Scout Lite](https://github.com/pingequalab/scout-lite).
 
-  Two things must be right or the app cannot open the port, and it tells you so
-  on screen rather than failing silently:
+  **Log Device must be Off** in Settings, System, or the app cannot open the
+  port: pins 13 and 14 are shared with the firmware serial log. The app detects
+  that conflict and says so on screen rather than failing silently.
 
-  - **Log Device must be Off** in Settings, System. Pins 13 and 14 are shared
-    with the firmware serial log.
-  - **5V on pin 1 comes from the OTG boost converter**, not a permanent rail.
-    While USB is plugged in the firmware defers OTG, so the scanner may have no
-    power until USB is unplugged and the app restarted.
+  5V on pin 1 has two sources and the app handles both -- USB VBUS while USB is
+  connected, and the OTG boost converter on battery -- so it runs on a car
+  charger and on battery alike. Unplugging USB mid-session restarts the scanner
+  board; the app notices and re-issues the scan command until the board answers
+  again.
 
   Do not power the scanner from pin 9. It is limited to 150 mA and a
   5 GHz-capable ESP32 exceeds that on transmit peaks.
@@ -102,6 +103,35 @@ description: |
   that file is what you upload to [WiGLE](https://wigle.net/).
 
 changelog: |
+  ## 0.2
+
+  Power handling. Both fixes come from a single wrong assumption about where the
+  5V on pin 1 comes from.
+
+  Fixed:
+
+  - The serial port would not open while USB was plugged in. The firmware keeps
+    the boost converter off while USB VBUS is above 4.5 V -- the charger refuses
+    it -- and feeds pin 1 straight from VBUS instead, so gating the port on the
+    boost state alone closed it on a board that had power the whole time. The
+    app now checks both sources.
+  - Unplugging USB stopped the survey without saying so. The handover to battery
+    succeeds, but the scanner board browns out and restarts into its
+    non-scanning state; nothing noticed, so collection could stop with nothing
+    on screen to show it. The app now detects the stall and re-issues the scan
+    command until the board answers, bounded at 24 attempts 5 seconds apart with
+    a 2 minute cap.
+
+  Added:
+
+  - Resync status on the Dash tab while the app is bringing the scanner back.
+
+  Changed:
+
+  - The OTG request is left standing while USB feeds pin 1, so the power service
+    raises the boost on its own the moment USB goes away. Handover from a car
+    charger to the battery no longer needs a restart.
+
   ## 0.1
 
   First public release. Wi-Fi survey front-end for the Flipper Zero driving an

--- a/applications/GPIO/sigroam/manifest.yml
+++ b/applications/GPIO/sigroam/manifest.yml
@@ -30,7 +30,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/pingequalab/sigroam-wardriving.git
-    commit_sha: 6f52553475f809a2276b51c8c8df9fffca5cb74b
+    commit_sha: 36f9ab5567c9fe5bffbec5b997a16a2fd84e587a
 
 screenshots:
   - screenshots/menu.png
@@ -81,9 +81,19 @@ description: |
   ## Hardware and setup
 
   Requires an ESP32 board running
-  [ESP32 Marauder](https://github.com/justcallmekoko/ESP32Marauder) firmware on
-  the GPIO header. Any Marauder-compatible board works; the reference board is
-  [Scout Lite](https://github.com/pingequalab/scout-lite).
+  [ESP32 Marauder](https://github.com/justcallmekoko/ESP32Marauder) firmware
+  on the GPIO header (pins 13 TX / 14 RX, 5V on pin 1).
+
+  The app speaks the Marauder serial protocol, not a specific product. It is
+  built for dual-band wardriving on **ESP32-C5 + GPS + microSD**: C5 sees
+  2.4 GHz and 5 GHz, GPS tags each network, and Marauder writes WiGLE CSV
+  to the scanner's own SD card. On-device verification used that combination.
+  Other Marauder-compatible boards that expose the same UART, GPS and SD
+  should work; they have not been bench-tested here.
+
+  GPS is optional: without it you get live counts, not locations. Logging
+  is the scanner's job -- SigRoam does not write survey data to the Flipper
+  SD card.
 
   **Log Device must be Off** in Settings, System, or the app cannot open the
   port: pins 13 and 14 are shared with the firmware serial log. The app detects
@@ -122,13 +132,10 @@ changelog: |
 
   Changed:
 
-  - A release now ships one .fap for both supported firmwares instead of one per
-    firmware. Loading is gated on the API major, which Official 1.4.3 and
-    Momentum mntm-012 share at 87, and building this source against both SDKs
-    produces files that differ in five bytes -- a debug-link checksum the loader
-    never reads and one byte of section size -- with every code, data,
-    relocation and symbol section byte-identical. Unleashed runs a different API
-    major and is still not covered.
+  - A release now ships one .fap instead of one per firmware. Loading is
+    gated on the API major. This build targets API 87 (Official firmware
+    1.4.3). CFW images that report the same API major can load the same
+    file; images on a different API major are not covered.
   - The GPS reading now comes from the survey data itself. The GPS tab used to
     be filled by a separate query the scanner answers only while it is not
     scanning, so the reading went stale exactly when it mattered. Every scan row
@@ -201,5 +208,4 @@ changelog: |
     karma, beacon or BLE spam, or password cracking -- permanently out of scope.
   - Survey data is not written to the Flipper SD card. Logging is the scanner's
     job; the Flipper provides control and live visibility.
-  - Builds against Official and Momentum firmware from the same source using
-    only the common Flipper API.
+  - Built against the official SDK (API 87) using only the common Flipper API.

--- a/applications/GPIO/sigroam/manifest.yml
+++ b/applications/GPIO/sigroam/manifest.yml
@@ -10,7 +10,7 @@
 #   name              <- name="SigRoam"
 #   id                <- appid="sigroam"
 #   category          <- fap_category="GPIO"
-#   version           <- fap_version="0.2"
+#   version           <- fap_version="0.3"
 #   short_description <- fap_description="Wi-Fi survey companion for external ESP32 scanners"
 #   author            <- fap_author="PINGEQUA_Lab"
 #   icon              <- fap_icon="icons/sigroam.png"  (verified 10x10, bit_depth=1, 96 B)
@@ -22,7 +22,7 @@
 # headers; none of those are in the subset, so pointing at those files would render badly on
 # the app page. Everything below stays inside the supported subset.
 
-# commit_sha is pinned to the commit the v0.2 tag points at -- the exact snapshot the
+# commit_sha is pinned to the commit the v0.3 tag points at -- the exact snapshot the
 # published release was built from -- not to whatever main happens to be at submission time.
 # The Catalog takes a sha precisely so a submission is reproducible; later commits on main
 # (documentation fixes and the like) must not silently change what was reviewed.
@@ -30,7 +30,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/pingequalab/sigroam-wardriving.git
-    commit_sha: 529257641a50f23e8b7f932715c7f7ab7794fd2f
+    commit_sha: 6f52553475f809a2276b51c8c8df9fffca5cb74b
 
 screenshots:
   - screenshots/menu.png
@@ -72,6 +72,8 @@ description: |
     did not recognise.
   - **Settings** for baud rate (six choices, default 115200), source codec,
     sound, vibro, backlight, stealth and debug rows, persisted across restarts.
+    Sound, vibro and the LED fire when the GPS fix is acquired or lost during a
+    survey; stealth suppresses the LED.
   - **Unique-BSSID estimate** from a 4 KB Bloom filter, session-scoped and
     RAM-only, as a progress indicator rather than a record of what you
     collected.
@@ -103,6 +105,45 @@ description: |
   that file is what you upload to [WiGLE](https://wigle.net/).
 
 changelog: |
+  ## 0.3
+
+  The notification switches, where the GPS reading comes from, scan control, and
+  one file to download instead of two.
+
+  Added:
+
+  - The sound, vibro, backlight and stealth switches now do something. They have
+    been in Settings since 0.1, stored and displayed but never read by anything.
+    They now drive an alert when the GPS fix changes state during a survey: a
+    rising two-note beep and a green blink when the fix is acquired, a falling
+    beep and a red blink when it is lost, and a short vibrate on either. Each
+    channel is gated on its own switch, stealth suppresses the LED, and alerts
+    are throttled to one every 3 seconds.
+
+  Changed:
+
+  - A release now ships one .fap for both supported firmwares instead of one per
+    firmware. Loading is gated on the API major, which Official 1.4.3 and
+    Momentum mntm-012 share at 87, and building this source against both SDKs
+    produces files that differ in five bytes -- a debug-link checksum the loader
+    never reads and one byte of section size -- with every code, data,
+    relocation and symbol section byte-identical. Unleashed runs a different API
+    major and is still not covered.
+  - The GPS reading now comes from the survey data itself. The GPS tab used to
+    be filled by a separate query the scanner answers only while it is not
+    scanning, so the reading went stale exactly when it mattered. Every scan row
+    already carries its own latitude, longitude and timestamp, and the tab now
+    reads those. Sampling still works while no scan is running.
+
+  Fixed:
+
+  - Pressing OK during a scan start or stop no longer stacks up commands. The
+    key was mapped from two states only, so a press while a stop was still in
+    flight sent another command on top of it, and a press after a failed stop
+    sent a start. All seven states are now mapped explicitly.
+  - A command that failed to reach the scanner no longer looked like it had been
+    sent.
+
   ## 0.2
 
   Power handling. Both fixes come from a single wrong assumption about where the


### PR DESCRIPTION
# Application Submission

SigRoam 0.4 — GPIO companion for an external ESP32 Marauder Wi-Fi scanner.

This PR stays on 0.4. `commit_sha` is `b5ebbacb642da173d277b1a1cfbbabe40a9b96ce` (public tag `v0.4`). Catalog description has no product link. Changelog names API 87 / Official 1.4.3 and CFW, not firmware forks. The in-app About short link resolves to the public GitHub repository.

0.4 adds capture-quality on the dashboard, Sess-tab identity, BLE-off, Dash/GPS layout, the About title line, Probe retry if the scanner does not answer, Waiting for first AP, POI: no fix in log, Dash skipping info on stock Marauder so a scan can start, ident hold until Version, and No SD / Saving overlay.

0.3 made the sound, vibro, backlight and stealth switches drive an alert on GPS fix transitions, reads GPS from the survey data itself, maps scan start/stop from all seven states, and ships a single .fap targeting API 87.

0.2 fixed a power gate that had refused to open the serial port whenever the Flipper was running on USB, and added automatic recovery when USB is unplugged mid-session.

SigRoam turns a Flipper Zero into the control head for an external ESP32 Marauder Wi-Fi scanner. It starts and stops scans over the GPIO serial port, shows AP, BLE and GPS counts live, and exposes the raw serial stream so a malformed feed is inspectable rather than invisible.

The Flipper has no Wi-Fi radio and does not scan by itself. The scanner board does the scanning and the logging; this app provides control and live visibility over the session.

**Receive-only by design.** The app never transmits attack traffic. Deauthentication and disassociation frames, WPA handshake capture, evil twin / karma / rogue AP, beacon and BLE spam, and password cracking of any kind are permanently out of scope -- a product rule, not a missing feature. The app only parses what the scanner prints.

Main features:

- **Dashboard** with four tabs: live counters, parsed record stream, GPS status, and session diagnostics. OK on the Dash tab starts and stops the scan, and the scan keeps running when you leave the page with Back.
- **Firmware probe** sends an info request and reports what answered, so "nothing connected" is distinguishable from "connected but not Marauder".
- **Raw log** shows unparsed serial lines, including anything the parser did not recognise.
- **Settings** for baud rate, source codec, sound, vibro, backlight, stealth and debug rows, persisted across restarts. Sound, vibro and the LED fire when the GPS fix is acquired or lost during a survey; stealth suppresses the LED.
- **Unique-BSSID estimate** from a 4 KB Bloom filter, session-scoped and RAM-only, presented as a progress indicator rather than as a record of what was collected.

Survey data is not written to the Flipper SD card; only settings are persisted. Marauder writes its own CSV to the scanner board's SD card, and that file is what the user uploads to WiGLE.

Built against the official SDK (API 87) using only the common Flipper API. CFW images that report the same API major can load the same file.

# Extra Requirements

**Extra hardware is required.** The app is a front-end and does nothing useful on its own:

- An ESP32 board running [ESP32 Marauder](https://github.com/justcallmekoko/ESP32Marauder) firmware on the GPIO header (pins 13 TX / 14 RX, 5V on pin 1). The app speaks the Marauder serial protocol, not a specific product. It is built for dual-band wardriving on ESP32-C5 + GPS + microSD. On-device verification used that combination; other Marauder-compatible boards that expose the same UART, GPS and SD should work and have not been bench-tested here.
- **Log Device must be set to Off** in Settings → System. Pins 13 and 14 are shared with the firmware serial log; the app detects this conflict and reports it on screen instead of failing silently.
- 5V on pin 1 has two sources and the app handles both: USB VBUS while USB is connected, and the OTG boost converter on battery. It verifies whichever one applies before opening the port, so running on a car charger and running on battery are equally supported.

No extra software beyond the scanner firmware is required.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out)

- Partially AI assisted - clarify below which parts were AI assisted and briefly explain what they do.

Design decisions -- module boundaries, the serial adapter interface, the receive-only scope, and every acceptance criterion -- were made and signed off by me and are recorded as ADRs in the repository. Drafting those documents was itself AI assisted; the decisions in them are mine. Implementation code inside those constraints, along with the host-side unit tests, was written with AI assistance and reviewed commit by commit before merging.

Specifically AI assisted: the pure-logic layer (line assembler, Marauder line and GPS block parsers, session state machine, Bloom filter) and its unit tests; the GUI view drawing code; and the serial I/O and worker-thread wrappers. Those modules do the parsing of scanner output, the aggregation of session counters, the rendering of the four dashboard tabs, and the buffered reading of the GPIO serial port.

Not AI assisted: hardware bring-up and all on-device verification, the firmware-compatibility decisions (the app deliberately avoids firmware-specific APIs so it builds on the official SDK and on CFW images that share API 87), the power and pin-conflict handling rules, and the safety scope that keeps the app receive-only.

# Reviewer Checklist (Don't fill this out, and don't remove it from the template)

- [ ] Bundle is valid
- [ ] There are no obvious issues with the source code
- [ ] I've ran this application and verified its functionality


