### PR TITLE
Add IR Builder 3.1 to Infrared

### DIFF
--- a/applications/Infrared/ir_builder/manifest.yml
+++ b/applications/Infrared/ir_builder/manifest.yml
@@ -1,0 +1,12 @@
+sourcecode:
+  type: git
+  location:
+    origin: https://github.com/sanoobis/IR-Builder.git
+    commit_sha: d58da713b9b4f94c96902958d75ee961561fa904
+short_description: "Create saved TV remotes from Universal Remote signal positions."
+description: "@docs/description.md"
+changelog: "@docs/changelog.md"
+screenshots:
+  - screenshots/screen_controller.png
+  - screenshots/screen_navigation.png
+  - screenshots/screen_home.png


### PR DESCRIPTION
# Application Submission

- Adds IR Builder 3.1 to the Infrared category.
- IR Builder creates saved TV remotes when the original remote is unavailable. Users can enter positions found with Universal Remotes or automatically scan candidate signals, pause when the TV responds, and save a standard infrared remote.
- It includes eight primary TV controls, eight navigation controls, editable saved projects, optional button imports, and a bundled 1,593-signal library that does not modify the firmware TV library.

# Extra Requirements

- No extra hardware or software is required beyond a Flipper Zero with a microSD card. A target TV is needed when testing candidate signals.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out)

- Partially AI assisted - the author designed and built IR Builder, chose its features and interface, supplied the Universal Remote signal positions, and performed the on-device testing. OpenAI Codex assisted with code review, debugging, build and catalog validation, and documentation.

# Reviewer Checklist (Don't fill this out, and don't remove it from the template)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
