### PR TITLE
Update IR Builder to 3.2

### DIFF
--- a/applications/Infrared/ir_builder/manifest.yml
+++ b/applications/Infrared/ir_builder/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/sanoobis/IR-Builder.git
-    commit_sha: d58da713b9b4f94c96902958d75ee961561fa904
+    commit_sha: 5b292b2656bc6966e6b87ff48116412c2d0de3c5
 short_description: "Create saved TV remotes from Universal Remote signal positions."
 description: "@docs/description.md"
 changelog: "@docs/changelog.md"


### PR DESCRIPTION
# Application Submission

- Updates IR Builder from 3.1 to 3.2.
- Adds **Open .ir** so an existing standard infrared remote can become an editable project.
- Maps common names onto 16 designed Power, Volume, Channel, Mute, navigation, Menu, Back, and Input controls.
- Preserves unmatched and duplicate signals on a third **Other buttons** screen.
- Saves standard exports under `infrared/ir_builder` and retains project formats 1 through 3 while writing format 4.
- The 31-signal Beko test remote mapped 16 controls and retained 15 other signals without changing their payloads.

# Extra Requirements

- No extra hardware or software is required beyond a Flipper Zero with a microSD card. A target TV is needed when testing candidate signals.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out)

- Partially AI assisted - the author designed and built IR Builder, chose its behavior and interface, supplied the reference remote data, and performed the device testing. OpenAI Codex assisted with code review, debugging, hardware test automation, build and catalog validation, and documentation.

# Reviewer Checklist (Don't fill this out, and don't remove it from the template)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
