### PR TITLE
Update Fake Chip Detector to 0.13 (GPIO)

### DIFF
--- a/applications/GPIO/fake_chip_detector/manifest.yml
+++ b/applications/GPIO/fake_chip_detector/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/hleserg/flipper-fake-chip-detector.git
-    commit_sha: 8a8aade4ea449940b432df8be809e82502764c14
+    commit_sha: 9bc39dcf07dbc61eab58da8ca864bd13223bbcef
     subdir: fake_chip_detector
 short_description: Check whether an I2C sensor really is the chip it was sold as, before you solder it in.
 description: "@docs/catalog_description.md"

--- a/applications/GPIO/fake_chip_detector/manifest.yml
+++ b/applications/GPIO/fake_chip_detector/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/hleserg/flipper-fake-chip-detector.git
-    commit_sha: 5742c220bdd4a1cf0788c099d2b1cd170a2e194f
+    commit_sha: 596862c52646cd5a4b461edb8fc81d9ff430418c
     subdir: fake_chip_detector
 short_description: Check whether an I2C sensor really is the chip it was sold as, before you solder it in.
 description: "@docs/catalog_description.md"

--- a/applications/GPIO/fake_chip_detector/manifest.yml
+++ b/applications/GPIO/fake_chip_detector/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/hleserg/flipper-fake-chip-detector.git
-    commit_sha: a412eeb153c9c0c9e6b7347068537a666f03526c
+    commit_sha: 8a8aade4ea449940b432df8be809e82502764c14
     subdir: fake_chip_detector
 short_description: Check whether an I2C sensor really is the chip it was sold as, before you solder it in.
 description: "@docs/catalog_description.md"

--- a/applications/GPIO/fake_chip_detector/manifest.yml
+++ b/applications/GPIO/fake_chip_detector/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/hleserg/flipper-fake-chip-detector.git
-    commit_sha: 189698d0e55238fe5a93c20740bd708bbb20b7d3
+    commit_sha: b546f7a37662cb2b19828eebe0b1b731c2fb6d50
     subdir: fake_chip_detector
 short_description: Check whether an I2C sensor really is the chip it was sold as, before you solder it in.
 description: "@docs/catalog_description.md"

--- a/applications/GPIO/fake_chip_detector/manifest.yml
+++ b/applications/GPIO/fake_chip_detector/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/hleserg/flipper-fake-chip-detector.git
-    commit_sha: b546f7a37662cb2b19828eebe0b1b731c2fb6d50
+    commit_sha: 5742c220bdd4a1cf0788c099d2b1cd170a2e194f
     subdir: fake_chip_detector
 short_description: Check whether an I2C sensor really is the chip it was sold as, before you solder it in.
 description: "@docs/catalog_description.md"

--- a/applications/GPIO/fake_chip_detector/manifest.yml
+++ b/applications/GPIO/fake_chip_detector/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/hleserg/flipper-fake-chip-detector.git
-    commit_sha: 9bc39dcf07dbc61eab58da8ca864bd13223bbcef
+    commit_sha: 189698d0e55238fe5a93c20740bd708bbb20b7d3
     subdir: fake_chip_detector
 short_description: Check whether an I2C sensor really is the chip it was sold as, before you solder it in.
 description: "@docs/catalog_description.md"


### PR DESCRIPTION
# Application Submission

Fake Chip Detector 0.13. The same PR as before, moved forward again rather than reopened.

**0.13 is your patch, @xMasterX.** Applied as written, with your authorship on the commit. Both diagnoses hold up on reading the code: `draw_right_key()` fills the rows `y-3`..`y+3`, so the `y=61` it was called with really did put its last row at 64 on a screen whose last row is 63, and the tip of the arrow was cut off on the *save log*, *details* and *find out* bars. And `Pad reads FLOATING` in FontPrimary is about 108px wide against a `< save` that starts at about 96px, so the two ran straight through each other. The hint is drawn first now and the title fitted to the room that is left, so no title can overlap it again — and the shortened titles fit outright, 63px in FontSecondary by the repository's own `tools/screen_width.py` and comfortably inside the 96px the hint leaves even in FontPrimary. The bottom-bar text moved from baseline 62 to 63 at the same time, so the row reads as one line rather than the text floating above the key glyphs.

I have not seen either fix on a screen: the Flipper had been unplugged by the time the patch arrived. They reproduce with nothing wired to the I²C pins at all, which is how you found them, and that is written down in `BACKLOG.md` rather than glossed.

**0.12 adds a live test for the QMC5883L**, the die a board silkscreened GY-271 most often carries. The app has been able to identify it since 0.7 and has had nothing further to say about it since — and a chip ID is one byte, which is exactly what a relabeller programs into a cheaper die.

The test asks the field to move by 240 counts on two different axes at the ±8 G range while the board is turned, and that is its only claim. There is no self-test half and there cannot be: this part's second control register holds `SOFT_RST`, `ROL_PNT` and `INT_ENB` and nothing else, so unlike the QMC5883P and the AK09911 it has no internal coil to fire on command. One honest proof is what the silicon supports. Every sequence in it is QST's own worked example — continuous mode, a measurement, standby, and the soft reset that parks the part on every exit path — each cited to document 13-52-04 Rev. B by section and page.

Two lessons from the parts already on this bench are applied from the start rather than after a bench session. The loop waits a sample period after every publish, which is what 0.11 had to add to the QMC5883P after it published a frame per bus round trip. And a pass needs at least eight readings behind it: the QMC5883P test has no such floor and once passed after two, which is few enough that a sensor reconnecting mid-test could have supplied the whole swing by itself.

**It has not been run on hardware.** No QMC5883L has been on this bench at all — the board that prompted the work carries a P — and the 240-count threshold is arithmetic off the datasheet's sensitivity figure, never compared against a still part. The file says so at the top, `LIVE_TESTS.md` says so, `BACKLOG.md` says so, and the description in this submission says so.

Sixteen live tests now, thirteen of which have never met the chip they were written for. Three parts have been driven end to end on real silicon: a VL6180X, an AK09911 and a QMC5883P. Two things about the AK09911 test are still unrun — the saturation screen, because no magnet has been held against a part, and the `RST` strap, because neither magnetometer board on the bench is wired for it.

**On the WIP question:** the app is not work in progress. It is marked beta because most of its live tests have never met the chip they were written for, and the description says that in the first paragraph rather than hiding it. If you would still rather the submission sat in Draft until more of them have, say so and I will move it.

# Extra Requirements

None beyond 0.7: an I2C device on pins 15 and 16, 3V3 and GND. No extra software.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

Validated both with and without `--nolint`; both bundle clean at `596862c`.

# AI usage disclosure (Fill this out)

- Partially AI assisted - clarify below which parts were AI assisted and briefly explain what they do.

Same arrangement as every version before it. The identification rewrite, the database rows, the magnetometer live tests and the fixes to them were written with Claude Code and reviewed by me before merge. Every register value in the new code is cited in a comment against the datasheet it came from, with document number, revision and page, and where a datasheet could not be obtained — the full AKM `MS1526-E-01` is not downloadable from any mirror I could reach — the comment says so and names what the value rests on instead. Where a datasheet was obtained but is silent, as QST's is on the self-test threshold, the code says that too rather than inventing a number. The identification rewrite is covered by a host test that runs in CI without a Flipper toolchain. The drawing fixes in 0.13 are @xMasterX's patch, applied unmodified.

# Reviewer Checklist (Don't fill this out, and don't remove it from the template)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
