### PR TITLE
Update UHF Expansion to 1.3

### DIFF
--- a/applications/GPIO/uhf_expansion/manifest.yml
+++ b/applications/GPIO/uhf_expansion/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/mtoolstec/fz-uhf-expansion.git
-    commit_sha: 6cbf422347938f6ce638ffb0efa36c25d0038f7d
+    commit_sha: bc3c6c59b96d426705481a3aa6c00ab623b2d0bf
 short_description: UHF RFID inventory reader over GPIO UART
 description: "@CATALOG.md"
 changelog: "@CHANGELOG.md"


### PR DESCRIPTION
# Application Submission

- Updates UHF Expansion to version 1.3.
- Uses source commit bc3c6c59b96d426705481a3aa6c00ab623b2d0bf after a successful release-SDK build and Catalog bundle validation.

# Extra Requirements

- Requires an MTools Tec UHF Expansion or compatible UCM601 UHF reader module.
- Uses Flipper Zero GPIO UART pins 13/14 and reset pin 16 on supported expansion revisions.

# Author Checklist (Fill this out)

- [x] I've read the [contribution guidelines](../blob/HEAD/documentation/Contributing.md) and my PR follows them
- [x] I own the code I'm submitting or have code owner's permission to submit it
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I [have validated](../blob/HEAD/documentation/Contributing.md#validating-manifest) the manifest file(s) with `python3 tools/bundle.py --nolint applications/CATEGORY/APPID/manifest.yml bundle.zip`

# AI usage disclosure (Fill this out)

- Partially AI assisted - AI assistance was used to create and review the release automation and Catalog metadata preparation. Source changes are reviewed and tested by the maintainer before a release commit is pushed.

# Reviewer Checklist (Don't fill this out, and don't remove it from the template)

- [x] Bundle is valid
- [x] There are no obvious issues with the source code
- [x] I've ran this application and verified its functionality
