### PR TITLE
Update Hotspot Arcade to 1.10.0

### DIFF
--- a/applications/GPIO/hotspot_arcade/manifest.yml
+++ b/applications/GPIO/hotspot_arcade/manifest.yml
@@ -2,7 +2,7 @@ sourcecode:
   type: git
   location:
     origin: https://github.com/tarikbc/hotspot-arcade.git
-    commit_sha: 3ae0fd2378f01ee092bfc07c3bd21ba8091cbb30
+    commit_sha: 6ed32fa8c61aa494fdc025249fa44adf96ff6e34
     subdir: flipper/hotspot-arcade
 id: hotspot_arcade
 category: GPIO


### PR DESCRIPTION
Bumps `hotspot_arcade` to 1.10.0 (fap_version `1.10.0`). The ESP firmware is unchanged
at v22, so nobody has to reflash their board.

Release: https://github.com/tarikbc/hotspot-arcade/releases/tag/v1.10.0

**A download per board.** The GitHub release now offers a `.fap` for each supported board
next to the combined one. A single-board build carries only that board firmware, so it is
about a third of the size and its first launch unpacks in a fraction of the time.

**Install Firmware lists only the boards the download can flash.** It used to offer all
three and fail at flash time on the two that were not there. It now reads what is bundled,
and skips the picker altogether when there is only one board to choose.

Note for this catalog in particular: nothing here changes. The catalog builds
`flipper/hotspot-arcade/` from source, which bundles all three board firmwares, so the
catalog app stays the full-featured build and keeps its `hotspot_arcade` folder on the SD
card. The per-board split applies only to the prebuilt downloads on GitHub.

Game count is unchanged at twenty, so the screenshots are unchanged.

Tested on the official ESP32-S2 dev board. Builds for all three supported boards.